### PR TITLE
Improve translator and enforce text style in UI

### DIFF
--- a/hoyo_buddy/bot/translator.py
+++ b/hoyo_buddy/bot/translator.py
@@ -151,7 +151,6 @@ class Translator:
         locale: "Locale",
         *,
         title_case: bool = False,
-        capitalize: bool = False,
         capitalize_first_word: bool = False,
     ) -> str:
         if isinstance(string, str):
@@ -211,8 +210,6 @@ class Translator:
 
         if title_case:
             translation = convert_to_title_case(translation)
-        elif capitalize:
-            translation = translation.capitalize()
         elif capitalize_first_word:
             translation = capitalize_first_word_(translation)
         return translation

--- a/hoyo_buddy/bot/translator.py
+++ b/hoyo_buddy/bot/translator.py
@@ -39,14 +39,12 @@ class LocaleStr:
         key: str | None = None,
         warn_no_key: bool = True,
         translate: bool = True,
-        no_modifiers: bool = False,
         **kwargs: Any,
     ) -> None:
         self.message = message
         self.key = key
         self.warn_no_key = warn_no_key
         self.translate_ = translate
-        self.no_modifiers = no_modifiers
         self.extras: dict[str, Any] = kwargs
 
     def __repr__(self) -> str:
@@ -204,9 +202,6 @@ class Translator:
 
         with contextlib.suppress(KeyError):
             translation = translation.format(**extras)
-
-        if string.no_modifiers:
-            return translation
 
         if title_case:
             translation = convert_to_title_case(translation)

--- a/hoyo_buddy/bot/translator.py
+++ b/hoyo_buddy/bot/translator.py
@@ -177,7 +177,7 @@ class Translator:
                     "String %r is missing on Transifex, added to not_translated", string_key
                 )
             elif (
-                source_string != message.format(**extras)
+                source_string.lower() != message.format(**extras).lower()
                 and self._env != "dev"
                 and string_key not in self._not_translated
             ):

--- a/hoyo_buddy/utils.py
+++ b/hoyo_buddy/utils.py
@@ -101,15 +101,12 @@ def convert_to_title_case(s: str) -> str:
     """
     # Capitalize the first letter of each word
     s = s.title()
-    # Lowercase minor words and articles
-    minor_words = r"(?i)\b(a|an|the|and|as|at|by|for|in|of|on|to|with|but|or|yet|so)\b"
-    s = re.sub(minor_words, lambda m: m.group(0).lower(), s)
-    # Capitalize the first and last words of a hyphenated word
-    s = re.sub(
-        r"(\b\w+)-(\w+)", lambda m: m.group(1).capitalize() + "-" + m.group(2).capitalize(), s
-    )
+    # Lowercase words that are three letters or fewer
+    s = re.sub(r"\b\w{1,3}\b", lambda m: m.group().lower(), s)
     # Capitalize first word
     s = capitalize_first_word(s)
+    # Capitalize the first word after a colon
+    s = re.sub(r"(?<=:)\s*\w+", lambda m: m.group().capitalize(), s)
     return s
 
 


### PR DESCRIPTION
# Summary
- Before adding the string to `not_translated`, check if the lowercase of source string is different from translation. If they are the same, then this situation is a case change, so don't publish the string to Transifex.
- Enforce text style in UI

## About Enforcing Text Style in UI
Currently, there are two types of text styles: title case and capitalize first word
### Title Case
Implemented in `utils.py` https://github.com/seriaati/hoyo-buddy/blob/ed89bf9569844e0e6da35ad33680ceb15fba7725/hoyo_buddy/utils.py#L97-L113
Used in:
- Embed title
- Embed field name
- Modal title
### Capitalize First Word
Implemented in `utils.py` https://github.com/seriaati/hoyo-buddy/blob/01a7cad254b8026bfafbbe073793f63877fd73f0/hoyo_buddy/utils.py#L113-L115
Note that this implementation **only** capitalizes the first word and leave the rest unchanged (this is intentional because certain terminologies like "AI" don't want to be lowercased). So use this feature with caution as it **does not** guarantee that the text style will be consistent, which is first word capitalized and the rest lowercased (except special terminologies).
Used in:
- Button label
- Select placeholder
- Select option label
- Select option description