### PR TITLE
Merge /abyss-enemies into /search

### DIFF
--- a/hoyo_buddy/cogs/hoyo.py
+++ b/hoyo_buddy/cogs/hoyo.py
@@ -22,7 +22,6 @@ from ..models import DrawInput
 from ..ui.hoyo.characters import CharactersView
 from ..ui.hoyo.checkin import CheckInUI
 from ..ui.hoyo.genshin.abyss import AbyssView
-from ..ui.hoyo.genshin.abyss_enemy import AbyssEnemyView
 from ..ui.hoyo.notes.view import NotesView
 from ..ui.hoyo.profile.view import ProfileView
 from ..ui.hoyo.redeem import RedeemUI
@@ -215,23 +214,6 @@ class Hoyo(commands.Cog):
         else:
             raise NotImplementedError
 
-        await view.start(i)
-
-    @app_commands.command(
-        name=app_commands.locale_str("abyss-enemies", translate=False),
-        description=app_commands.locale_str(
-            "View the current abyss enemies", key="abyss_command_description"
-        ),
-    )
-    async def abyss_enemies_command(self, i: "INTERACTION") -> None:
-        settings = await Settings.get(user_id=i.user.id)
-
-        view = AbyssEnemyView(
-            dark_mode=settings.dark_mode,
-            author=i.user,
-            locale=settings.locale or i.locale,
-            translator=self.bot.translator,
-        )
         await view.start(i)
 
     @app_commands.command(

--- a/hoyo_buddy/hoyo/clients/ambr_client.py
+++ b/hoyo_buddy/hoyo/clients/ambr_client.py
@@ -65,6 +65,7 @@ class ItemCategory(StrEnum):
     LIVING_BEINGS = "Living Beings"
     BOOKS = "Books"
     TCG = "TCG"
+    SPIRAL_ABYSS = "Spiral Abyss"
 
 
 class AmbrAPIClient(ambr.AmbrAPI):  # noqa: PLR0904
@@ -242,6 +243,8 @@ class AmbrAPIClient(ambr.AmbrAPI):  # noqa: PLR0904
                 return await self.fetch_books()
             case ItemCategory.TCG:
                 return await self.fetch_tcg_cards()
+            case ItemCategory.SPIRAL_ABYSS:
+                return []
 
     def get_character_embed(
         self,


### PR DESCRIPTION
# Summary
Merge the command `/abyss-enemies` into the `/search` command.  
This PR tries to change as little code as possible.

## Technical Details
- Remove command interface of `/abyss-enemies` in `cogs/hoyo.py`
- Add new static method `get_autocomplete_choices` in `AbyssEnemyView` to conveniently get autocomplete choices for the query parameter. The choices are the dates of the abyss seasons, with a special symbol indicating the current one.
- Add spiral abyss to the `ItemCategory` enum into `clients/ambr_client.py`
- Update the search command accordingly to handle the `SPIRAL_ABYSS` item category
- Update the auto complete choice method accordingly to handle autocomplete choices for the `SPIRAL_ABYSS` item category