### PR TITLE
Use Locale Directly for Draw Function Inputs

### DIFF
--- a/hoyo_buddy/draw/funcs/hoyo/farm.py
+++ b/hoyo_buddy/draw/funcs/hoyo/farm.py
@@ -5,7 +5,6 @@ from typing import TYPE_CHECKING
 from PIL import Image, ImageDraw
 
 from hoyo_buddy.draw.drawer import DARK_SURFACE, LIGHT_SURFACE, WHITE, Drawer
-from hoyo_buddy.enums import Locale
 from hoyo_buddy.l10n import LocaleStr, translator
 
 if TYPE_CHECKING:
@@ -13,12 +12,13 @@ if TYPE_CHECKING:
 
     import ambr
 
+    from hoyo_buddy.enums import Locale
     from hoyo_buddy.models import FarmData
 
 __all__ = ("draw_farm_card",)
 
 
-def draw_farm_card(farm_data: list[FarmData], locale_: str, dark_mode: bool) -> io.BytesIO:
+def draw_farm_card(farm_data: list[FarmData], locale: Locale, dark_mode: bool) -> io.BytesIO:
     def get_domain_title(domain: ambr.Domain, locale: Locale) -> str:
         """Get the title of a GI domain based on its name and city, assuming the language is English."""
         city_name = translator.translate(LocaleStr(custom_str=domain.city.name.title()), locale)
@@ -28,7 +28,6 @@ def draw_farm_card(farm_data: list[FarmData], locale_: str, dark_mode: bool) -> 
         domain_type_name = translator.translate(domain_type, locale)
         return f"{domain_type_name} ({city_name})"
 
-    locale = Locale(locale_)
     mode = "dark" if dark_mode else "light"
     basic_cards: list[Image.Image] = []
 

--- a/hoyo_buddy/draw/funcs/hoyo/genshin/build_card.py
+++ b/hoyo_buddy/draw/funcs/hoyo/genshin/build_card.py
@@ -20,14 +20,13 @@ __all__ = ("draw_genshin_card",)
 
 
 def draw_genshin_card(
-    locale_: str,
+    locale: Locale,
     dark_mode: bool,
     character: Character | HoyolabGICharacter,
     image_url: str,
     zoom: float,
     rank: str | None,
 ) -> io.BytesIO:
-    locale = Locale(locale_)
     mode = "dark" if dark_mode else "light"
     text_color = (241, 241, 241) if dark_mode else (33, 33, 33)
 

--- a/hoyo_buddy/draw/funcs/hoyo/genshin/characters.py
+++ b/hoyo_buddy/draw/funcs/hoyo/genshin/characters.py
@@ -5,7 +5,6 @@ from typing import TYPE_CHECKING
 from PIL import Image, ImageDraw
 
 from hoyo_buddy.draw.drawer import BLACK, DARK_SURFACE, LIGHT_SURFACE, WHITE, Drawer
-from hoyo_buddy.enums import Locale
 from hoyo_buddy.l10n import LevelStr, LocaleStr
 from hoyo_buddy.models import DynamicBKInput, UnownedGICharacter
 
@@ -14,6 +13,8 @@ if TYPE_CHECKING:
     from collections.abc import Sequence
 
     from genshin.models import GenshinDetailCharacter as GICharacter
+
+    from hoyo_buddy.enums import Locale
 
 
 PC_ICON_OFFSETS = (0, -29)
@@ -27,9 +28,8 @@ def draw_character_card(
     pc_icons: dict[str, str],
     talent_orders: dict[str, list[int]],
     dark_mode: bool,
-    locale_: str,
+    locale: Locale,
 ) -> io.BytesIO:
-    locale = Locale(locale_)
     c_cards: dict[str, Image.Image] = {}
 
     for character in characters:

--- a/hoyo_buddy/draw/funcs/hoyo/genshin/notes.py
+++ b/hoyo_buddy/draw/funcs/hoyo/genshin/notes.py
@@ -5,7 +5,6 @@ from typing import TYPE_CHECKING
 from PIL import ImageDraw
 
 from hoyo_buddy.draw.drawer import Drawer
-from hoyo_buddy.enums import Locale
 from hoyo_buddy.l10n import LocaleStr
 from hoyo_buddy.utils import format_timedelta
 
@@ -14,12 +13,13 @@ if TYPE_CHECKING:
 
     from genshin.models import Notes
 
+    from hoyo_buddy.enums import Locale
+
 __all__ = ("draw_genshin_notes_card",)
 
 
-def draw_genshin_notes_card(notes: Notes, locale_: str, dark_mode: bool) -> BytesIO:
+def draw_genshin_notes_card(notes: Notes, locale: Locale, dark_mode: bool) -> BytesIO:
     filename = f"{'dark' if dark_mode else 'light'}-gi"
-    locale = Locale(locale_)
     im = Drawer.open_image(f"hoyo-buddy-assets/assets/notes/{filename}.png")
     draw = ImageDraw.Draw(im)
     drawer = Drawer(draw, folder="gi-notes", dark_mode=dark_mode)

--- a/hoyo_buddy/draw/funcs/hoyo/hsr/build_card.py
+++ b/hoyo_buddy/draw/funcs/hoyo/hsr/build_card.py
@@ -7,23 +7,21 @@ from PIL import Image, ImageDraw
 
 from hoyo_buddy.draw.drawer import BLACK, WHITE, Drawer
 from hoyo_buddy.draw.funcs.hoyo.hsr.common import get_character_skills, get_character_stats
-from hoyo_buddy.enums import Locale
 
 if TYPE_CHECKING:
     import io
 
     import hoyo_buddy.models as hb_models
+    from hoyo_buddy.enums import Locale
 
 
 def draw_hsr_build_card(
     character: enka.hsr.Character | hb_models.HoyolabHSRCharacter,
-    locale_: str,
+    locale: Locale,
     dark_mode: bool,
     image_url: str,
     primary_hex: str,
 ) -> io.BytesIO:
-    locale = Locale(locale_)
-
     primary = Drawer.hex_to_rgb(primary_hex)
     if dark_mode:
         # blend with dark gray

--- a/hoyo_buddy/draw/funcs/hoyo/hsr/characters.py
+++ b/hoyo_buddy/draw/funcs/hoyo/hsr/characters.py
@@ -6,13 +6,14 @@ from genshin.models import StarRailDetailCharacter as HSRCharacter
 from PIL import Image, ImageDraw
 
 from hoyo_buddy.draw.drawer import DARK_SURFACE, LIGHT_SURFACE, Drawer
-from hoyo_buddy.enums import Locale
 from hoyo_buddy.l10n import LevelStr, LocaleStr
 from hoyo_buddy.models import DynamicBKInput, UnownedHSRCharacter
 
 if TYPE_CHECKING:
     import io
     from collections.abc import Sequence
+
+    from hoyo_buddy.enums import Locale
 
 
 WEAPON_ICON_POS = (356, 17)
@@ -23,9 +24,8 @@ def draw_character_card(
     characters: Sequence[HSRCharacter | UnownedHSRCharacter],
     pc_icons: dict[str, str],
     dark_mode: bool,
-    locale_: str,
+    locale: Locale,
 ) -> io.BytesIO:
-    locale = Locale(locale_)
     c_cards: dict[str, Image.Image] = {}
 
     for character in characters:

--- a/hoyo_buddy/draw/funcs/hoyo/hsr/notes.py
+++ b/hoyo_buddy/draw/funcs/hoyo/hsr/notes.py
@@ -17,8 +17,7 @@ if TYPE_CHECKING:
 __all__ = ("draw_hsr_notes_card",)
 
 
-def draw_hsr_notes_card(notes: StarRailNote, locale_: str, dark_mode: bool) -> BytesIO:
-    locale = Locale(locale_)
+def draw_hsr_notes_card(notes: StarRailNote, locale: Locale, dark_mode: bool) -> BytesIO:
     filename = f"{'dark' if dark_mode else 'light'}-hsr"
     im = Drawer.open_image(f"hoyo-buddy-assets/assets/notes/{filename}.png")
     draw = ImageDraw.Draw(im)

--- a/hoyo_buddy/draw/funcs/hoyo/zzz/notes.py
+++ b/hoyo_buddy/draw/funcs/hoyo/zzz/notes.py
@@ -22,7 +22,7 @@ def get_nearest_battery_level(current: int, max_battery: int) -> int:
     return battery_levels[bisect.bisect_left(battery_levels, percentage)]
 
 
-def draw_zzz_notes(notes: ZZZNotes, locale_: str, dark_mode: bool) -> BytesIO:
+def draw_zzz_notes(notes: ZZZNotes, locale: Locale, dark_mode: bool) -> BytesIO:
     battery_level = get_nearest_battery_level(
         notes.battery_charge.current, notes.battery_charge.max
     )
@@ -30,9 +30,7 @@ def draw_zzz_notes(notes: ZZZNotes, locale_: str, dark_mode: bool) -> BytesIO:
     filename = f"{'dark' if dark_mode else 'light'}_notes_{battery_level}"
     im = Drawer.open_image(f"hoyo-buddy-assets/assets/zzz-notes/{filename}.png")
     draw = ImageDraw.Draw(im)
-    drawer = Drawer(
-        draw, folder="zzz-notes", dark_mode=dark_mode, locale=Locale(locale_), sans=True
-    )
+    drawer = Drawer(draw, folder="zzz-notes", dark_mode=dark_mode, locale=locale, sans=True)
 
     # Title
     drawer.write(

--- a/hoyo_buddy/draw/funcs/item_list.py
+++ b/hoyo_buddy/draw/funcs/item_list.py
@@ -4,7 +4,6 @@ from typing import TYPE_CHECKING
 
 from PIL import Image, ImageDraw
 
-from hoyo_buddy.enums import Locale
 from hoyo_buddy.models import ItemWithDescription, ItemWithTrailing
 
 from ..drawer import (
@@ -19,11 +18,12 @@ from ..drawer import (
 if TYPE_CHECKING:
     from io import BytesIO
 
+    from hoyo_buddy.enums import Locale
+
 
 def draw_item_list(
-    items: list[ItemWithDescription] | list[ItemWithTrailing], dark_mode: bool, locale_: str
+    items: list[ItemWithDescription] | list[ItemWithTrailing], dark_mode: bool, locale: Locale
 ) -> BytesIO:
-    locale = Locale(locale_)
     is_trailing = any(isinstance(item, ItemWithTrailing) for item in items)
 
     # Variables

--- a/hoyo_buddy/draw/main_funcs.py
+++ b/hoyo_buddy/draw/main_funcs.py
@@ -55,11 +55,7 @@ async def draw_item_list_card(
         [item.icon for item in items if item.icon is not None], "item-list", draw_input.session
     )
     buffer = await draw_input.loop.run_in_executor(
-        draw_input.executor,
-        funcs.draw_item_list,
-        items,
-        draw_input.dark_mode,
-        draw_input.locale.value,
+        draw_input.executor, funcs.draw_item_list, items, draw_input.dark_mode, draw_input.locale
     )
     buffer.seek(0)
     return File(buffer, filename=draw_input.filename)
@@ -111,7 +107,7 @@ async def draw_hsr_build_card(
             draw_input.executor,
             funcs.hsr.draw_hsr_build_card,
             character,
-            draw_input.locale.value,
+            draw_input.locale,
             draw_input.dark_mode,
             image_url,
             primary_hex,
@@ -123,7 +119,7 @@ async def draw_hsr_build_card(
 
     card = funcs.hsr.HSRBuildCard2(
         character,
-        locale=draw_input.locale.value,
+        locale=draw_input.locale,
         dark_mode=draw_input.dark_mode,
         image_url=image_url,
         en_name=en_name,
@@ -141,7 +137,7 @@ async def draw_hsr_notes_card(draw_input: DrawInput, notes: StarRailNote) -> Byt
         draw_input.executor,
         funcs.hsr.draw_hsr_notes_card,
         notes,
-        draw_input.locale.value,
+        draw_input.locale,
         draw_input.dark_mode,
     )
 
@@ -171,7 +167,7 @@ async def draw_gi_build_card(
 
         await download_images(urls, "gi-build-card2", draw_input.session)
         card = funcs.genshin.GITempTwoBuildCard(
-            locale=draw_input.locale.value,
+            locale=draw_input.locale,
             character=character,
             zoom=zoom,
             dark_mode=draw_input.dark_mode,
@@ -186,7 +182,7 @@ async def draw_gi_build_card(
         buffer = await draw_input.loop.run_in_executor(
             draw_input.executor,
             funcs.genshin.draw_genshin_card,
-            draw_input.locale.value,
+            draw_input.locale,
             draw_input.dark_mode,
             character,
             image_url,
@@ -206,7 +202,7 @@ async def draw_gi_notes_card(draw_input: DrawInput, notes: genshin.models.Notes)
         draw_input.executor,
         funcs.genshin.draw_genshin_notes_card,
         notes,
-        draw_input.locale.value,
+        draw_input.locale,
         draw_input.dark_mode,
     )
 
@@ -222,7 +218,7 @@ async def draw_farm_card(draw_input: DrawInput, farm_data: list[FarmData]) -> Fi
         draw_input.executor,
         funcs.draw_farm_card,
         farm_data,
-        draw_input.locale.value,
+        draw_input.locale,
         draw_input.dark_mode,
     )
     buffer.seek(0)
@@ -256,7 +252,7 @@ async def draw_gi_characters_card(
         pc_icons,
         talent_orders,
         draw_input.dark_mode,
-        draw_input.locale.value,
+        draw_input.locale,
     )
     buffer.seek(0)
 
@@ -282,7 +278,7 @@ async def draw_hsr_characters_card(
         characters,
         pc_icons,
         draw_input.dark_mode,
-        draw_input.locale.value,
+        draw_input.locale,
     )
     buffer.seek(0)
 
@@ -321,7 +317,7 @@ async def draw_spiral_abyss_card(
     traveler = next((c for c in characters if c.id in TRAVELER_IDS), None)
     card = funcs.genshin.SpiralAbyssCard(
         abyss,
-        locale=draw_input.locale.value,
+        locale=draw_input.locale,
         character_icons=character_icons,
         character_ranks=character_ranks,
         traveler_element=traveler.element if traveler is not None else None,
@@ -334,7 +330,7 @@ async def draw_spiral_abyss_card(
 async def draw_exploration_card(draw_input: DrawInput, user: PartialGenshinUserStats) -> File:
     buffer = await draw_input.loop.run_in_executor(
         draw_input.executor,
-        funcs.genshin.ExplorationCard(user, draw_input.dark_mode, draw_input.locale.value).draw,
+        funcs.genshin.ExplorationCard(user, draw_input.dark_mode, draw_input.locale).draw,
     )
     buffer.seek(0)
     return File(buffer, filename=draw_input.filename)
@@ -348,7 +344,7 @@ async def draw_moc_card(
         await download_images(icons, "moc", draw_input.session)
 
     buffer = await draw_input.loop.run_in_executor(
-        draw_input.executor, funcs.hsr.moc.MOCCard(data, season, draw_input.locale.value).draw
+        draw_input.executor, funcs.hsr.moc.MOCCard(data, season, draw_input.locale).draw
     )
     buffer.seek(0)
     return File(buffer, filename=draw_input.filename)
@@ -363,7 +359,7 @@ async def draw_pure_fiction_card(
 
     buffer = await draw_input.loop.run_in_executor(
         draw_input.executor,
-        funcs.hsr.pure_fiction.PureFictionCard(data, season, draw_input.locale.value).draw,
+        funcs.hsr.pure_fiction.PureFictionCard(data, season, draw_input.locale).draw,
     )
     buffer.seek(0)
     return File(buffer, filename=draw_input.filename)
@@ -378,7 +374,7 @@ async def draw_apc_shadow_card(
 
     buffer = await draw_input.loop.run_in_executor(
         draw_input.executor,
-        funcs.hsr.apc_shadow.APCShadowCard(data, season, draw_input.locale.value).draw,
+        funcs.hsr.apc_shadow.APCShadowCard(data, season, draw_input.locale).draw,
     )
     buffer.seek(0)
     return File(buffer, filename=draw_input.filename)
@@ -415,7 +411,7 @@ async def draw_img_theater_card(
     buffer = await draw_input.loop.run_in_executor(
         draw_input.executor,
         funcs.genshin.ImgTheaterCard(
-            data, chara_consts, character_icons, draw_input.locale.value, traveler_element
+            data, chara_consts, character_icons, draw_input.locale, traveler_element
         ).draw,
     )
 
@@ -428,7 +424,7 @@ async def draw_zzz_notes_card(draw_input: DrawInput, notes: ZZZNotes) -> BytesIO
         draw_input.executor,
         funcs.zzz.draw_zzz_notes,
         notes,
-        draw_input.locale.value,
+        draw_input.locale,
         draw_input.dark_mode,
     )
 
@@ -559,7 +555,7 @@ async def draw_zzz_build_card(
 
     if template == 3:
         card = funcs.zzz.ZZZTeamCard(
-            locale=draw_input.locale.value,
+            locale=draw_input.locale,
             agents=[agent],
             agent_colors={agent.id: custom_color or card_data["color"]},
             agent_images={agent.id: image},
@@ -573,7 +569,7 @@ async def draw_zzz_build_card(
     elif template == 4:
         card = funcs.zzz.ZZZAgentCard4(
             agent,
-            locale=draw_input.locale.value,
+            locale=draw_input.locale,
             name_data=draw_data.name_data.get(agent.id),
             image_url=image,
             disc_icons=draw_data.disc_icons,
@@ -586,7 +582,7 @@ async def draw_zzz_build_card(
     else:
         card = funcs.zzz.ZZZAgentCard(
             agent,
-            locale=draw_input.locale.value,
+            locale=draw_input.locale,
             name_data=draw_data.name_data.get(agent.id),
             image_url=image,
             card_data=card_data,
@@ -616,7 +612,7 @@ async def draw_zzz_characters_card(
         funcs.zzz.draw_big_agent_card,
         agents,
         draw_input.dark_mode,
-        draw_input.locale.value,
+        draw_input.locale,
     )
     buffer.seek(0)
 
@@ -635,7 +631,7 @@ async def draw_honkai_suits_card(draw_input: DrawInput, suits: Sequence[FullBatt
         draw_input.executor,
         funcs.hoyo.honkai.draw_big_suit_card,
         suits,
-        draw_input.locale.value,
+        draw_input.locale,
         draw_input.dark_mode,
     )
     buffer.seek(0)
@@ -660,7 +656,7 @@ async def draw_zzz_team_card(
     await download_images(urls, "zzz-team-card", draw_input.session)
 
     card = funcs.zzz.ZZZTeamCard(
-        locale=draw_input.locale.value,
+        locale=draw_input.locale,
         agents=agents,
         agent_colors=agent_colors,
         agent_images=agent_custom_images,
@@ -698,7 +694,7 @@ async def draw_hsr_team_card(
     await download_images(urls, "hsr-team-card", draw_input.session)
 
     card = funcs.hsr.HSRTeamCard(
-        locale=draw_input.locale.value,
+        locale=draw_input.locale,
         characters=characters,
         character_images=character_images,
         character_colors=character_colors,
@@ -721,7 +717,7 @@ async def draw_gi_team_card(
     await download_images(urls, "gi-team-card", draw_input.session)
 
     card = funcs.genshin.GITeamCard(
-        locale=draw_input.locale.value,
+        locale=draw_input.locale,
         dark_mode=draw_input.dark_mode,
         characters=characters,
         character_images=character_images,
@@ -765,7 +761,7 @@ async def draw_shiyu_card(
     urls.extend(bangboo.icon for bangboo in bangboos)
     await download_images(urls, "shiyu", draw_input.session)
 
-    card = funcs.zzz.ShiyuDefenseCard(shiyu, agent_ranks, uid, locale=draw_input.locale.value)
+    card = funcs.zzz.ShiyuDefenseCard(shiyu, agent_ranks, uid, locale=draw_input.locale)
     buffer = await draw_input.loop.run_in_executor(draw_input.executor, card.draw)
 
     buffer.seek(0)
@@ -807,7 +803,7 @@ async def draw_assault_card(
             urls.append(challenge.bangboo.icon)
     await download_images(urls, "assault", draw_input.session)
 
-    card = funcs.zzz.AssaultCard(data, draw_input.locale.value, uid)
+    card = funcs.zzz.AssaultCard(data, draw_input.locale, uid)
     buffer = await draw_input.loop.run_in_executor(draw_input.executor, card.draw)
     buffer.seek(0)
     return File(buffer, filename=draw_input.filename)


### PR DESCRIPTION
Previous implementations pass in Locale as str because `discord.Locale` enums are can't be pickled, now that a custom `Locale` enum is used, we can pass in `Locale` directly.