### PR TITLE
Save Image as WebP Instead of PNG

### DIFF
--- a/hoyo_buddy/cogs/others.py
+++ b/hoyo_buddy/cogs/others.py
@@ -179,9 +179,9 @@ class Others(commands.Cog):
         # brand image
         image_ = discord.File(
             SettingsUI.get_brand_img_filename("DARK" if settings.dark_mode else "LIGHT", locale),
-            filename="brand.png",
+            filename="brand.webp",
         )
-        embed.set_image(url="attachment://brand.png")
+        embed.set_image(url="attachment://brand.webp")
 
         view.message = await i.edit_original_response(
             embed=embed, attachments=[image_], view=view, content=await get_dyk(i)

--- a/hoyo_buddy/commands/characters.py
+++ b/hoyo_buddy/commands/characters.py
@@ -68,7 +68,7 @@ class CharactersCommand:
             dark_mode=settings.dark_mode,
             locale=draw_locale(locale, account),
             session=i.client.session,
-            filename="characters.png",
+            filename="characters.webp",
             executor=i.client.executor,
             loop=i.client.loop,
         )

--- a/hoyo_buddy/commands/farm.py
+++ b/hoyo_buddy/commands/farm.py
@@ -83,7 +83,7 @@ class FarmCommand:
                 dark_mode=self._settings.dark_mode,
                 locale=draw_locale(self.locale, farm_notify.account),
                 session=i.client.session,
-                filename="farm_notify.png",
+                filename="farm_notify.webp",
                 executor=i.client.executor,
                 loop=i.client.loop,
             ),

--- a/hoyo_buddy/draw/drawer.py
+++ b/hoyo_buddy/draw/drawer.py
@@ -654,7 +654,7 @@ class Drawer:
         """Save an image to a BytesIO object, resizing it if it exceeds the Discord file size limit."""
         while True:
             bytes_obj = io.BytesIO()
-            img.save(bytes_obj, format="WEBP")
+            img.save(bytes_obj, format="WEBP", lossless=True)
             size_in_bytes = bytes_obj.tell()
 
             if size_in_bytes < DC_MAX_FILESIZE:

--- a/hoyo_buddy/draw/drawer.py
+++ b/hoyo_buddy/draw/drawer.py
@@ -654,7 +654,7 @@ class Drawer:
         """Save an image to a BytesIO object, resizing it if it exceeds the Discord file size limit."""
         while True:
             bytes_obj = io.BytesIO()
-            img.save(bytes_obj, format="PNG")
+            img.save(bytes_obj, format="WEBP")
             size_in_bytes = bytes_obj.tell()
 
             if size_in_bytes < DC_MAX_FILESIZE:

--- a/hoyo_buddy/hoyo/auto_tasks/notes_check.py
+++ b/hoyo_buddy/hoyo/auto_tasks/notes_check.py
@@ -205,7 +205,7 @@ class NotesChecker:
 
         embed.add_acc_info(notify.account, blur=False)
         embed.set_footer(text=LocaleStr(key="notif.embed.footer"))
-        embed.set_image(url="attachment://notes.png")
+        embed.set_image(url="attachment://notes.webp")
         return embed
 
     @classmethod
@@ -227,7 +227,7 @@ class NotesChecker:
                 dark_mode=account.user.settings.dark_mode,
                 locale=draw_locale(locale, account),
                 session=cls._bot.session,
-                filename="notes.png",
+                filename="notes.webp",
                 executor=cls._bot.executor,
                 loop=cls._bot.loop,
             )
@@ -245,7 +245,7 @@ class NotesChecker:
                 file_ = None
             else:
                 buffer.seek(0)
-                file_ = discord.File(buffer, filename="notes.png")
+                file_ = discord.File(buffer, filename="notes.webp")
 
             view = View(author=None, locale=locale)
             buttons = NotesView.get_open_game_buttons(account)

--- a/hoyo_buddy/ui/hoyo/challenge.py
+++ b/hoyo_buddy/ui/hoyo/challenge.py
@@ -408,7 +408,7 @@ class ChallengeView(View):
             dark_mode=self.dark_mode,
             locale=locale,
             session=session,
-            filename="challenge.png",
+            filename="challenge.webp",
             executor=executor,
             loop=loop,
         )
@@ -474,7 +474,7 @@ class ChallengeView(View):
             return
 
         embed = DefaultEmbed(self.locale).add_acc_info(self.account)
-        embed.set_image(url="attachment://challenge.png")
+        embed.set_image(url="attachment://challenge.webp")
 
         await item.unset_loading_state(i, embed=embed, attachments=[file_])
 
@@ -519,7 +519,7 @@ class ChallengeView(View):
         self.check_challenge_data(self.challenge)
         file_ = await self.draw_card(i.client.session, i.client.executor, i.client.loop)
         embed = DefaultEmbed(self.locale).add_acc_info(self.account)
-        embed.set_image(url="attachment://challenge.png")
+        embed.set_image(url="attachment://challenge.webp")
 
         self.message = await i.edit_original_response(
             embed=embed, attachments=[file_], view=self, content=await get_dyk(i)

--- a/hoyo_buddy/ui/hoyo/characters.py
+++ b/hoyo_buddy/ui/hoyo/characters.py
@@ -410,7 +410,7 @@ class CharactersView(PaginatorView):
 
     def _get_embed(self, char_num: int) -> DefaultEmbed:
         embed = DefaultEmbed(self.locale, title=LocaleStr(key="characters.embed.title"))
-        embed.set_image(url="attachment://characters.png")
+        embed.set_image(url="attachment://characters.webp")
         embed.add_acc_info(self.account)
 
         if self.game is Game.HONKAI:

--- a/hoyo_buddy/ui/hoyo/checkin.py
+++ b/hoyo_buddy/ui/hoyo/checkin.py
@@ -119,7 +119,7 @@ class CheckInUI(View):
                 dark_mode=self.dark_mode,
                 locale=draw_locale(self.locale, self.account),
                 session=session,
-                filename="check-in.png",
+                filename="check-in.webp",
                 executor=executor,
                 loop=loop,
             ),
@@ -135,7 +135,7 @@ class CheckInUI(View):
                 missed=info.missed_rewards,
             ),
         )
-        embed.set_image(url="attachment://check-in.png")
+        embed.set_image(url="attachment://check-in.webp")
         embed.add_acc_info(self.account)
         return embed, bytes_obj
 
@@ -145,7 +145,7 @@ class CheckInUI(View):
         )
 
         self._bytes_obj.seek(0)
-        file_ = discord.File(self._bytes_obj, filename="check-in.png")
+        file_ = discord.File(self._bytes_obj, filename="check-in.webp")
         await i.followup.send(embed=embed, file=file_, view=self, content=await get_dyk(i))
         self.message = await i.original_response()
 
@@ -176,7 +176,7 @@ class CheckInButton(Button[CheckInUI]):
         )
 
         self.view._bytes_obj.seek(0)
-        file_ = discord.File(self.view._bytes_obj, filename="check-in.png")
+        file_ = discord.File(self.view._bytes_obj, filename="check-in.webp")
 
         await i.edit_original_response(embed=embed, attachments=[file_])
         embed = client.get_daily_reward_embed(daily_reward, self.view.locale, blur=True)

--- a/hoyo_buddy/ui/hoyo/event_calendar.py
+++ b/hoyo_buddy/ui/hoyo/event_calendar.py
@@ -177,7 +177,7 @@ class EventCalendarView(ui.View):
                 session=bot.session,
                 executor=bot.executor,
                 loop=bot.loop,
-                filename="rewards.png",
+                filename="rewards.webp",
             ),
             list(itertools.batched(blocks, 4)),
         )
@@ -227,7 +227,7 @@ class BannerSelector(ItemSelector):
             self.view.locale,
             title=self.get_option_name(banner),
             description=get_duration_str(banner),
-        ).set_image(url="attachment://banner_items.png")
+        ).set_image(url="attachment://banner_items.webp")
 
     async def draw_banner_items(
         self, bot: HoyoBuddy, banner: genshin.models.Banner | genshin.models.EventWarp
@@ -248,7 +248,7 @@ class BannerSelector(ItemSelector):
                 session=bot.session,
                 executor=bot.executor,
                 loop=bot.loop,
-                filename="banner_items.png",
+                filename="banner_items.webp",
             ),
             list(itertools.batched(blocks, 4)),
         )
@@ -295,7 +295,7 @@ class EventSelector(ItemSelector):
                 title=event.name,
                 description=f"{get_duration_str(event)}\n\n{event.description}",
             )
-            .set_image(url="attachment://rewards.png")
+            .set_image(url="attachment://rewards.webp")
             .add_field(
                 name=LocaleStr(key="finished_status_field_name"), value=status_str, inline=False
             )
@@ -433,7 +433,7 @@ class ChallengeSelector(ItemSelector):
             self.view.locale,
             title=self.get_option_name(challenge),
             description=get_duration_str(challenge),
-        ).set_image(url="attachment://rewards.png")
+        ).set_image(url="attachment://rewards.webp")
         if star is not None and max_star is not None:
             embed.add_field(
                 name=LocaleStr(key="music_grade", mi18n_game=Game.GENSHIN),

--- a/hoyo_buddy/ui/hoyo/genshin/abyss_enemy.py
+++ b/hoyo_buddy/ui/hoyo/genshin/abyss_enemy.py
@@ -102,7 +102,7 @@ class AbyssEnemyView(View):
             embed = client.get_abyss_chamber_embed_with_floor_info(
                 floor, self._floor_index, chamber, self._chamber_index, abyss.blessing
             )
-            embed.set_image(url="attachment://enemies.png")
+            embed.set_image(url="attachment://enemies.webp")
 
             items = client.get_abyss_chamber_enemy_items(
                 chamber,
@@ -128,7 +128,7 @@ class AbyssEnemyView(View):
                 dark_mode=self._dark_mode,
                 locale=self.locale,
                 session=i.client.session,
-                filename="enemies.png",
+                filename="enemies.webp",
                 executor=i.client.executor,
                 loop=i.client.loop,
             ),

--- a/hoyo_buddy/ui/hoyo/genshin/build.py
+++ b/hoyo_buddy/ui/hoyo/genshin/build.py
@@ -82,7 +82,7 @@ class GIBuildView(ui.View):
     def _get_use_rate_embed(self, key: str) -> DefaultEmbed:
         return (
             DefaultEmbed(self.locale, title=LocaleStr(key=key))
-            .set_image(url="attachment://use_rate.png")
+            .set_image(url="attachment://use_rate.webp")
             .set_author(name=self.character.name, icon_url=self.character.icon)
             .set_footer(text="genshin.aza.gg")
         )
@@ -152,7 +152,7 @@ class GIBuildView(ui.View):
                 session=bot.session,
                 executor=bot.executor,
                 loop=bot.loop,
-                filename="use_rate.png",
+                filename="use_rate.webp",
             ),
             [list(chunk) for chunk in chunked_blocks],
         )
@@ -209,7 +209,7 @@ class GIBuildView(ui.View):
                 session=bot.session,
                 executor=bot.executor,
                 loop=bot.loop,
-                filename="use_rate.png",
+                filename="use_rate.webp",
             ),
             [list(chunk) for chunk in chunked_blocks],
         )
@@ -259,7 +259,7 @@ class GIBuildView(ui.View):
                 session=bot.session,
                 executor=bot.executor,
                 loop=bot.loop,
-                filename="synergy_team.png",
+                filename="synergy_team.webp",
             ),
             block_lists,
         )
@@ -295,7 +295,7 @@ class GIBuildView(ui.View):
         synergy = self.guide.gw_data.synergies
         embed = DefaultEmbed(self.locale, title=synergy.title)
         embed.set_footer(text=f"{synergy.credits}\nGenshin Wizard")
-        embed.set_image(url="attachment://synergy_team.png")
+        embed.set_image(url="attachment://synergy_team.webp")
         embed.set_author(name=self.character.name, icon_url=self.character.icon)
 
         if synergy.info:

--- a/hoyo_buddy/ui/hoyo/genshin/exploration.py
+++ b/hoyo_buddy/ui/hoyo/genshin/exploration.py
@@ -37,7 +37,7 @@ class ExplorationView(ui.View):
         return (
             DefaultEmbed(self.locale)
             .add_acc_info(self.account)
-            .set_image(url="attachment://exploration.png")
+            .set_image(url="attachment://exploration.webp")
         )
 
     @property
@@ -53,7 +53,7 @@ class ExplorationView(ui.View):
                 dark_mode=self.dark_mode,
                 locale=draw_locale(self.locale, self.account),
                 session=bot.session,
-                filename="exploration.png",
+                filename="exploration.webp",
                 executor=bot.executor,
                 loop=bot.loop,
             ),

--- a/hoyo_buddy/ui/hoyo/genshin/farm.py
+++ b/hoyo_buddy/ui/hoyo/genshin/farm.py
@@ -67,7 +67,7 @@ class FarmView(View):
             dark_mode=self._dark_mode,
             locale=self.locale,
             session=i.client.session,
-            filename="farm.png",
+            filename="farm.webp",
             executor=i.client.executor,
             loop=i.client.loop,
         )

--- a/hoyo_buddy/ui/hoyo/genshin/farm_notify.py
+++ b/hoyo_buddy/ui/hoyo/genshin/farm_notify.py
@@ -45,7 +45,7 @@ class FarmNotifyView(PaginatorView):
                     )
                 )
                 .add_acc_info(farm_notify.account)
-                .set_image(url="attachment://farm_notify.png")
+                .set_image(url="attachment://farm_notify.webp")
             )
             for i in range(len(self._split_item_ids))
         ]

--- a/hoyo_buddy/ui/hoyo/notes/view.py
+++ b/hoyo_buddy/ui/hoyo/notes/view.py
@@ -315,7 +315,7 @@ class NotesView(View):
     async def get_reminder_embed(self) -> DefaultEmbed:
         embed = DefaultEmbed(self.locale, title=LocaleStr(key="reminder_settings_title"))
         embed.add_acc_info(self.account)
-        embed.set_image(url="attachment://notes.png")
+        embed.set_image(url="attachment://notes.webp")
 
         if self.account.game is Game.GENSHIN:
             return await self._get_gi_embed(embed)
@@ -653,7 +653,7 @@ class NotesView(View):
                     )
                 )
 
-        return embed.set_image(url="attachment://notes.png").add_acc_info(self.account)
+        return embed.set_image(url="attachment://notes.webp").add_acc_info(self.account)
 
     async def start(self, i: Interaction, *, acc_select: AccountSwitcher | None = None) -> None:
         self._add_items()
@@ -666,13 +666,13 @@ class NotesView(View):
                 dark_mode=self.dark_mode,
                 locale=draw_locale(self.locale, self.account),
                 session=i.client.session,
-                filename="notes.png",
+                filename="notes.webp",
                 executor=i.client.executor,
                 loop=i.client.loop,
             )
             self.bytes_obj = await self._draw_notes_card(notes, draw_input)
             self.bytes_obj.seek(0)
-            file_ = File(self.bytes_obj, filename="notes.png")
+            file_ = File(self.bytes_obj, filename="notes.webp")
         else:
             file_ = None
 

--- a/hoyo_buddy/ui/hoyo/profile/view.py
+++ b/hoyo_buddy/ui/hoyo/profile/view.py
@@ -323,7 +323,7 @@ class ProfileView(View):
     @property
     def card_embed(self) -> DefaultEmbed:
         embed = DefaultEmbed(self.locale)
-        embed.set_image(url="attachment://card.png")
+        embed.set_image(url="attachment://card.webp")
         if self._account is not None:
             embed.add_acc_info(self._account)
         else:
@@ -569,7 +569,7 @@ class ProfileView(View):
             dark_mode=card_settings.dark_mode,
             locale=await self.get_character_locale(character),
             session=i.client.session,
-            filename="card.png",
+            filename="card.webp",
             executor=i.client.executor,
             loop=i.client.loop,
         )
@@ -612,7 +612,7 @@ class ProfileView(View):
             dark_mode=settings.team_card_dark_mode,
             locale=locale,
             session=i.client.session,
-            filename="card.png",
+            filename="card.webp",
             executor=i.client.executor,
             loop=i.client.loop,
         )
@@ -761,7 +761,7 @@ class ProfileView(View):
                 raise ThirdPartyCardTempError from e
             raise
 
-        attachments = [File(bytes_obj, filename="card.png")]
+        attachments = [File(bytes_obj, filename="card.webp")]
 
         if unset_loading_state and item is not None:
             await item.unset_loading_state(

--- a/hoyo_buddy/ui/settings.py
+++ b/hoyo_buddy/ui/settings.py
@@ -37,14 +37,14 @@ class SettingsUI(View):
 
     def get_embed(self) -> DefaultEmbed:
         embed = DefaultEmbed(self.locale)
-        embed.set_image(url="attachment://brand.png")
+        embed.set_image(url="attachment://brand.webp")
         return embed
 
     def get_brand_image_file(self, interaction_locale: Locale) -> discord.File:
         theme = "DARK" if self.settings.dark_mode else "LIGHT"
         locale = self.settings.locale or interaction_locale
         filename = self.get_brand_img_filename(theme, locale)
-        return discord.File(filename, filename="brand.png")
+        return discord.File(filename, filename="brand.webp")
 
     async def update_ui_and_save_settings(self, i: Interaction, *, translate: bool = False) -> None:
         if translate:


### PR DESCRIPTION
Discord can display webp, which has smaller file size than png. Discord also supports animated webp, which paves the road for #372.