### PR TITLE
Redis Image Cache + Better Statch Image Paths

### DIFF
--- a/hoyo_buddy/config.py
+++ b/hoyo_buddy/config.py
@@ -29,6 +29,7 @@ class Config(BaseSettings):
     db_url: str
     fernet_key: str
     proxy: str
+    redis_url: str | None = None
 
     # Command-line arguments
     search: bool = False

--- a/hoyo_buddy/constants.py
+++ b/hoyo_buddy/constants.py
@@ -1210,4 +1210,4 @@ SUPPORTER_ROLE_ID = 1376358430947676184 if CONFIG.is_dev else 111799263382708225
 
 HB_BIRTHDAY = datetime.date(2024, 6, 7)
 
-POOL_MAX_WORKERS = min(32, (os.cpu_count() or 1) + 4)
+POOL_MAX_WORKERS = 1 if CONFIG.is_dev else min(32, (os.cpu_count() or 1) + 4)

--- a/hoyo_buddy/constants.py
+++ b/hoyo_buddy/constants.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import datetime
+import os
 import pathlib
 from typing import TYPE_CHECKING, Final, Literal
 
@@ -1208,3 +1209,5 @@ GUILD_ID = 1131592943791263745 if CONFIG.is_dev else 1000727526194298910
 SUPPORTER_ROLE_ID = 1376358430947676184 if CONFIG.is_dev else 1117992633827082251
 
 HB_BIRTHDAY = datetime.date(2024, 6, 7)
+
+POOL_MAX_WORKERS = min(32, (os.cpu_count() or 1) + 4)

--- a/hoyo_buddy/draw/drawer.py
+++ b/hoyo_buddy/draw/drawer.py
@@ -461,13 +461,11 @@ class Drawer:
         self,
         url: str,
         *,
-        folder: str | None = None,
         size: tuple[int, int] | None = None,
         mask_color: tuple[int, int, int] | None = None,
         opacity: float = 1.0,
     ) -> Image.Image:
-        folder = folder or self.folder
-        image = self.open_image(get_static_img_path(url, folder), size)
+        image = self.open_image(get_static_img_path(url), size)
 
         if mask_color is not None:
             image = self.mask_image_with_color(image, mask_color, opacity=opacity)

--- a/hoyo_buddy/draw/main_funcs.py
+++ b/hoyo_buddy/draw/main_funcs.py
@@ -53,7 +53,7 @@ async def draw_item_list_card(
     draw_input: DrawInput, items: list[ItemWithDescription] | list[ItemWithTrailing]
 ) -> File:
     await download_images(
-        [item.icon for item in items if item.icon is not None], "item-list", draw_input.session
+        [item.icon for item in items if item.icon is not None], draw_input.session
     )
     buffer = await draw_input.loop.run_in_executor(
         draw_input.executor, funcs.draw_item_list, items, draw_input.dark_mode, draw_input.locale
@@ -63,7 +63,7 @@ async def draw_item_list_card(
 
 
 async def draw_checkin_card(draw_input: DrawInput, rewards: list[Reward]) -> BytesIO:
-    await download_images([r.icon for r in rewards], "check-in", draw_input.session)
+    await download_images([r.icon for r in rewards], draw_input.session)
     return await draw_input.loop.run_in_executor(
         draw_input.executor, funcs.draw_checkin_card, rewards, draw_input.dark_mode
     )
@@ -101,7 +101,7 @@ async def draw_hsr_build_card(
     if template == 2:
         urls.extend(e.icon for e in character.eidolons)
 
-    await download_images(urls, f"hsr-build-card{'2' if template == 2 else ''}", draw_input.session)
+    await download_images(urls, draw_input.session)
 
     if template == 1:
         return await draw_input.loop.run_in_executor(
@@ -130,9 +130,7 @@ async def draw_hsr_build_card(
 
 async def draw_hsr_notes_card(draw_input: DrawInput, notes: StarRailNote) -> BytesIO:
     await download_images(
-        [exped.item_url for exped in notes.expeditions],
-        folder="hsr-notes",
-        session=draw_input.session,
+        [exped.item_url for exped in notes.expeditions], session=draw_input.session
     )
     return await draw_input.loop.run_in_executor(
         draw_input.executor,
@@ -166,7 +164,7 @@ async def draw_gi_build_card(
                 msg = f"Character {character.id} not found in Amber's database."
                 raise ValueError(msg)
 
-        await download_images(urls, "gi-build-card2", draw_input.session)
+        await download_images(urls, draw_input.session)
         card = funcs.genshin.GITempTwoBuildCard(
             locale=draw_input.locale,
             character=character,
@@ -179,7 +177,7 @@ async def draw_gi_build_card(
         )
         buffer = await draw_input.loop.run_in_executor(draw_input.executor, card.draw)
     else:
-        await download_images(urls, "gi-build-card", draw_input.session)
+        await download_images(urls, draw_input.session)
         buffer = await draw_input.loop.run_in_executor(
             draw_input.executor,
             funcs.genshin.draw_genshin_card,
@@ -195,9 +193,7 @@ async def draw_gi_build_card(
 
 async def draw_gi_notes_card(draw_input: DrawInput, notes: genshin.models.Notes) -> BytesIO:
     await download_images(
-        [exped.character_icon for exped in notes.expeditions],
-        folder="gi-notes",
-        session=draw_input.session,
+        [exped.character_icon for exped in notes.expeditions], session=draw_input.session
     )
     return await draw_input.loop.run_in_executor(
         draw_input.executor,
@@ -214,7 +210,7 @@ async def draw_farm_card(draw_input: DrawInput, farm_data: list[FarmData]) -> Fi
         + [c.icon for data in farm_data for c in data.characters]
         + [w.icon for data in farm_data for w in data.weapons]
     )
-    await download_images(image_urls, folder="farm", session=draw_input.session)
+    await download_images(image_urls, session=draw_input.session)
     buffer = await draw_input.loop.run_in_executor(
         draw_input.executor,
         funcs.draw_farm_card,
@@ -236,7 +232,7 @@ async def draw_gi_characters_card(
     urls: list[str] = [c.weapon.icon for c in characters if not isinstance(c, UnownedGICharacter)]
     urls.extend(pc_icons[str(c.id)] for c in characters if str(c.id) in pc_icons)
 
-    await download_images(urls, "gi-characters", draw_input.session)
+    await download_images(urls, draw_input.session)
     buffer = await draw_input.loop.run_in_executor(
         draw_input.executor,
         funcs.genshin.draw_character_card,
@@ -263,7 +259,7 @@ async def draw_hsr_characters_card(
         urls.append(c.equip.icon)
     urls.extend(pc_icons[str(c.id)] for c in characters if str(c.id) in pc_icons)
 
-    await download_images(urls, "hsr-characters", draw_input.session)
+    await download_images(urls, draw_input.session)
     buffer = await draw_input.loop.run_in_executor(
         draw_input.executor,
         funcs.hsr.draw_character_card,
@@ -304,7 +300,7 @@ async def draw_spiral_abyss_card(
                 abyss.ranks.strongest_strike[0],
             )
         )
-    await download_images(urls, "abyss", draw_input.session)
+    await download_images(urls, draw_input.session)
 
     traveler = next((c for c in characters if c.id in TRAVELER_IDS), None)
     card = funcs.genshin.SpiralAbyssCard(
@@ -333,7 +329,7 @@ async def draw_moc_card(
 ) -> File:
     for floor in data.floors:
         icons = [chara.icon for chara in floor.node_1.avatars + floor.node_2.avatars]
-        await download_images(icons, "moc", draw_input.session)
+        await download_images(icons, draw_input.session)
 
     buffer = await draw_input.loop.run_in_executor(
         draw_input.executor, funcs.hsr.moc.MOCCard(data, season, draw_input.locale, uid).draw
@@ -350,7 +346,7 @@ async def draw_pure_fiction_card(
 ) -> File:
     for floor in data.floors:
         icons = [chara.icon for chara in floor.node_1.avatars + floor.node_2.avatars]
-        await download_images(icons, "pf", draw_input.session)
+        await download_images(icons, draw_input.session)
 
     buffer = await draw_input.loop.run_in_executor(
         draw_input.executor,
@@ -365,7 +361,7 @@ async def draw_apc_shadow_card(
 ) -> File:
     for floor in data.floors:
         icons = [chara.icon for chara in floor.node_1.avatars + floor.node_2.avatars]
-        await download_images(icons, "apc-shadow", draw_input.session)
+        await download_images(icons, draw_input.session)
 
     buffer = await draw_input.loop.run_in_executor(
         draw_input.executor,
@@ -401,7 +397,7 @@ async def draw_img_theater_card(
     for act in data.acts:
         icons.extend(character_icons.get(str(chara.id), "") for chara in act.characters)
 
-    await download_images(icons, "img-theater", draw_input.session)
+    await download_images(icons, draw_input.session)
 
     buffer = await draw_input.loop.run_in_executor(
         draw_input.executor,
@@ -539,14 +535,7 @@ async def draw_zzz_build_card(
         urls.append(agent.w_engine.icon)
 
     agent_special_stats = agent_special_stat_map.get(str(agent.id), [])
-
-    if template == 3:
-        folder = "zzz-team-card"
-    elif template == 4:
-        folder = "zzz-build-card4"
-    else:  # 1, 2
-        folder = "zzz-build-card"
-    await download_images(urls, folder, draw_input.session)
+    await download_images(urls, draw_input.session)
 
     if template == 3:
         card = funcs.zzz.ZZZTeamCard(
@@ -601,7 +590,7 @@ async def draw_zzz_characters_card(
         if isinstance(agent, ZZZFullAgent) and agent.w_engine is not None:
             urls.append(agent.w_engine.icon)
 
-    await download_images(urls, "zzz-characters", draw_input.session)
+    await download_images(urls, draw_input.session)
     buffer = await draw_input.loop.run_in_executor(
         draw_input.executor,
         funcs.zzz.draw_big_agent_card,
@@ -620,7 +609,7 @@ async def draw_honkai_suits_card(draw_input: DrawInput, suits: Sequence[FullBatt
         urls.extend((suit.tall_icon.replace(" ", ""), suit.weapon.icon))
         urls.extend(stig.icon for stig in suit.stigmata)
 
-    await download_images(urls, "honkai-characters", draw_input.session, ignore_error=True)
+    await download_images(urls, draw_input.session, ignore_error=True)
 
     buffer = await draw_input.loop.run_in_executor(
         draw_input.executor,
@@ -648,7 +637,7 @@ async def draw_zzz_team_card(
     urls = list(agent_custom_images.values())
     urls.extend(agent.w_engine.icon for agent in agents if agent.w_engine is not None)
     urls.extend(draw_data.disc_icons.values())
-    await download_images(urls, "zzz-team-card", draw_input.session)
+    await download_images(urls, draw_input.session)
 
     card = funcs.zzz.ZZZTeamCard(
         locale=draw_input.locale,
@@ -686,7 +675,7 @@ async def draw_hsr_team_card(
         else:
             urls.extend(stat.icon for stat in character.stats)
 
-    await download_images(urls, "hsr-team-card", draw_input.session)
+    await download_images(urls, draw_input.session)
 
     card = funcs.hsr.HSRTeamCard(
         locale=draw_input.locale,
@@ -709,7 +698,7 @@ async def draw_gi_team_card(
         urls.extend(artifact.icon for artifact in character.artifacts)
         urls.append(character.weapon.icon)
 
-    await download_images(urls, "gi-team-card", draw_input.session)
+    await download_images(urls, draw_input.session)
 
     card = funcs.genshin.GITeamCard(
         locale=draw_input.locale,
@@ -754,7 +743,7 @@ async def draw_shiyu_card(
         for character in floor.node_1.characters + floor.node_2.characters
     ]
     urls.extend(bangboo.icon for bangboo in bangboos)
-    await download_images(urls, "shiyu", draw_input.session)
+    await download_images(urls, draw_input.session)
 
     card = funcs.zzz.ShiyuDefenseCard(shiyu, agent_ranks, uid, locale=draw_input.locale)
     buffer = await draw_input.loop.run_in_executor(draw_input.executor, card.draw)
@@ -778,7 +767,7 @@ async def draw_block_list_card(
             else:
                 urls.extend((block.icon1, block.icon2))
 
-    await download_images(urls, "block-list", draw_input.session)
+    await download_images(urls, draw_input.session)
 
     card = funcs.block_list.BlockListCard(block_lists, dark_mode=draw_input.dark_mode)
     buffer = await draw_input.loop.run_in_executor(draw_input.executor, card.draw)
@@ -796,7 +785,7 @@ async def draw_assault_card(
         urls.extend(agent.icon for agent in challenge.agents)
         if challenge.bangboo is not None:
             urls.append(challenge.bangboo.icon)
-    await download_images(urls, "assault", draw_input.session)
+    await download_images(urls, draw_input.session)
 
     card = funcs.zzz.AssaultCard(data, draw_input.locale, uid)
     buffer = await draw_input.loop.run_in_executor(draw_input.executor, card.draw)
@@ -812,7 +801,7 @@ async def draw_hard_challenge(
     for challenge in challenges:
         urls.append(challenge.enemy.icon)
         urls.extend(char.icon for char in challenge.team)
-    await download_images(urls, "hard-challenge", draw_input.session)
+    await download_images(urls, draw_input.session)
 
     card = funcs.genshin.HardChallengeCard(data, uid, draw_input.locale, mode=mode)
     buffer = await draw_input.loop.run_in_executor(draw_input.executor, card.draw)

--- a/hoyo_buddy/draw/static.py
+++ b/hoyo_buddy/draw/static.py
@@ -52,11 +52,7 @@ async def download_image_task(
 
 
 async def download_images(
-    image_urls: Sequence[str],
-    folder: str,
-    session: aiohttp.ClientSession,
-    *,
-    ignore_error: bool = False,
+    image_urls: Sequence[str], session: aiohttp.ClientSession, *, ignore_error: bool = False
 ) -> None:
     tasks: list[asyncio.Task] = []
 
@@ -64,7 +60,7 @@ async def download_images(
         if not image_url:
             continue
 
-        file_path = get_static_img_path(image_url, folder)
+        file_path = get_static_img_path(image_url)
         if file_path.exists():
             continue
         task = asyncio.create_task(

--- a/hoyo_buddy/redis.py
+++ b/hoyo_buddy/redis.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import io
+import os
+from concurrent.futures import ThreadPoolExecutor
+
+import redis
+from loguru import logger
+from PIL import Image
+
+from hoyo_buddy.config import CONFIG
+
+
+class RedisImageCache:
+    def __init__(self, redis_url: str) -> None:
+        logger.info(f"Process {os.getpid()} creating redis connection pool...")
+        self.redis = redis.ConnectionPool.from_url(redis_url)
+        self.bg_executor = ThreadPoolExecutor(max_workers=4, thread_name_prefix="RedisCacheWorker")
+
+    def set(self, key: str, image: Image.Image) -> None:
+        try:
+            with redis.Redis(connection_pool=self.redis) as r, io.BytesIO() as output:
+                image.save(output, format="PNG")
+                r.set(key, output.getvalue())
+        except redis.RedisError as e:
+            logger.error(f"Redis error while setting image {key}: {e}")
+
+    def set_background(self, key: str, image: Image.Image) -> None:
+        self.bg_executor.submit(self.set, key, image.copy())
+
+    def get(self, key: str) -> Image.Image | None:
+        try:
+            with redis.Redis(connection_pool=self.redis) as r:
+                image_data = r.get(key)
+                if image_data is None:
+                    return None
+        except redis.RedisError as e:
+            logger.error(f"Redis error while getting image {key}: {e}")
+            return None
+        else:
+            return Image.open(io.BytesIO(image_data))  # pyright: ignore[reportArgumentType]
+
+    def disconnect(self) -> None:
+        """Disconnect from the Redis server."""
+        self.bg_executor.shutdown(wait=False, cancel_futures=True)
+        self.redis.disconnect()
+        logger.info(f"Process {os.getpid()} disconnected from Redis.")
+
+
+image_cache = RedisImageCache(redis_url=CONFIG.redis_url) if CONFIG.redis_url else None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ dependencies = [
   "pydantic-settings>=2.7.1",
   "ambr-py",
   "apscheduler>=3.11.0",
+  "redis[hiredis]>=6.2.0",
 ]
 description = "A feature-rich Discord bot for Hoyoverse gamers."
 license = { file = "LICENSE" }

--- a/run.py
+++ b/run.py
@@ -27,7 +27,7 @@ async def main() -> None:
     wrap_task_factory()
 
     if CONFIG.is_dev:
-        executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+        executor = concurrent.futures.ThreadPoolExecutor(max_workers=POOL_MAX_WORKERS)
     else:
         executor = concurrent.futures.ProcessPoolExecutor(max_workers=POOL_MAX_WORKERS)
 

--- a/uv.lock
+++ b/uv.lock
@@ -776,6 +776,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "hiredis"
+version = "3.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f7/08/24b72f425b75e1de7442fb1740f69ca66d5820b9f9c0e2511ff9aadab3b7/hiredis-3.2.1.tar.gz", hash = "sha256:5a5f64479bf04dd829fe7029fad0ea043eac4023abc6e946668cbbec3493a78d", size = 89096, upload-time = "2025-05-23T11:41:57.227Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/60/a1/6da1578a22df1926497f7a3f6a3d2408fe1d1559f762c1640af5762a8eb6/hiredis-3.2.1-cp312-cp312-macosx_10_15_universal2.whl", hash = "sha256:3742d8b17e73c198cabeab11da35f2e2a81999d406f52c6275234592256bf8e8", size = 82627, upload-time = "2025-05-23T11:40:15.362Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/b1/1056558ca8dc330be5bb25162fe5f268fee71571c9a535153df9f871a073/hiredis-3.2.1-cp312-cp312-macosx_10_15_x86_64.whl", hash = "sha256:9c2f3176fb617a79f6cccf22cb7d2715e590acb534af6a82b41f8196ad59375d", size = 45404, upload-time = "2025-05-23T11:40:16.72Z" },
+    { url = "https://files.pythonhosted.org/packages/58/4f/13d1fa1a6b02a99e9fed8f546396f2d598c3613c98e6c399a3284fa65361/hiredis-3.2.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:a8bd46189c7fa46174e02670dc44dfecb60f5bd4b67ed88cb050d8f1fd842f09", size = 43299, upload-time = "2025-05-23T11:40:17.697Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/25/ddfac123ba5a32eb1f0b40ba1b2ec98a599287f7439def8856c3c7e5dd0d/hiredis-3.2.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f86ee4488c8575b58139cdfdddeae17f91e9a893ffee20260822add443592e2f", size = 172194, upload-time = "2025-05-23T11:40:19.143Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/1e/443a3703ce570b631ca43494094fbaeb051578a0ebe4bfcefde351e1ba25/hiredis-3.2.1-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3717832f4a557b2fe7060b9d4a7900e5de287a15595e398c3f04df69019ca69d", size = 168429, upload-time = "2025-05-23T11:40:20.329Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/d6/0d8c6c706ed79b2298c001b5458c055615e3166533dcee3900e821a18a3e/hiredis-3.2.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e5cb12c21fb9e2403d28c4e6a38120164973342d34d08120f2d7009b66785644", size = 182967, upload-time = "2025-05-23T11:40:21.921Z" },
+    { url = "https://files.pythonhosted.org/packages/da/68/da8dd231fbce858b5a20ab7d7bf558912cd125f08bac4c778865ef5fe2c2/hiredis-3.2.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:080fda1510bbd389af91f919c11a4f2aa4d92f0684afa4709236faa084a42cac", size = 172495, upload-time = "2025-05-23T11:40:23.105Z" },
+    { url = "https://files.pythonhosted.org/packages/65/25/83a31420535e2778662caa95533d5c997011fa6a88331f0cdb22afea9ec3/hiredis-3.2.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1252e10a1f3273d1c6bf2021e461652c2e11b05b83e0915d6eb540ec7539afe2", size = 173142, upload-time = "2025-05-23T11:40:24.24Z" },
+    { url = "https://files.pythonhosted.org/packages/41/d7/cb907348889eb75e2aa2e6b63e065b611459e0f21fe1e371a968e13f0d55/hiredis-3.2.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:d9e320e99ab7d2a30dc91ff6f745ba38d39b23f43d345cdee9881329d7b511d6", size = 166433, upload-time = "2025-05-23T11:40:25.287Z" },
+    { url = "https://files.pythonhosted.org/packages/01/5d/7cbc69d82af7b29a95723d50f5261555ba3d024bfbdc414bdc3d23c0defb/hiredis-3.2.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:641668f385f16550fdd6fdc109b0af6988b94ba2acc06770a5e06a16e88f320c", size = 164883, upload-time = "2025-05-23T11:40:26.454Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/00/f995b1296b1d7e0247651347aa230f3225a9800e504fdf553cf7cd001cf7/hiredis-3.2.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:1e1f44208c39d6c345ff451f82f21e9eeda6fe9af4ac65972cc3eeb58d41f7cb", size = 177262, upload-time = "2025-05-23T11:40:27.576Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/f3/723a67d729e94764ce9e0d73fa5f72a0f87d3ce3c98c9a0b27cbf001cc79/hiredis-3.2.1-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:f882a0d6415fffe1ffcb09e6281d0ba8b1ece470e866612bbb24425bf76cf397", size = 169619, upload-time = "2025-05-23T11:40:29.671Z" },
+    { url = "https://files.pythonhosted.org/packages/45/58/f69028df00fb1b223e221403f3be2059ae86031e7885f955d26236bdfc17/hiredis-3.2.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:b4e78719a0730ebffe335528531d154bc8867a246418f74ecd88adbc4d938c49", size = 167303, upload-time = "2025-05-23T11:40:30.902Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/7d/567411e65cce76cf265a9a4f837fd2ebc564bef6368dd42ac03f7a517c0a/hiredis-3.2.1-cp312-cp312-win32.whl", hash = "sha256:33c4604d9f79a13b84da79950a8255433fca7edaf292bbd3364fd620864ed7b2", size = 20551, upload-time = "2025-05-23T11:40:32.69Z" },
+    { url = "https://files.pythonhosted.org/packages/90/74/b4c291eb4a4a874b3690ff9fc311a65d5292072556421b11b1d786e3e1d0/hiredis-3.2.1-cp312-cp312-win_amd64.whl", hash = "sha256:7b9749375bf9d171aab8813694f379f2cff0330d7424000f5e92890ad4932dc9", size = 22128, upload-time = "2025-05-23T11:40:33.686Z" },
+    { url = "https://files.pythonhosted.org/packages/47/91/c07e737288e891c974277b9fa090f0a43c72ab6ccb5182117588f1c01269/hiredis-3.2.1-cp313-cp313-macosx_10_15_universal2.whl", hash = "sha256:7cabf7f1f06be221e1cbed1f34f00891a7bdfad05b23e4d315007dd42148f3d4", size = 82636, upload-time = "2025-05-23T11:40:35.035Z" },
+    { url = "https://files.pythonhosted.org/packages/92/20/02cb1820360eda419bc17eb835eca976079e2b3e48aecc5de0666b79a54c/hiredis-3.2.1-cp313-cp313-macosx_10_15_x86_64.whl", hash = "sha256:db85cb86f8114c314d0ec6d8de25b060a2590b4713135240d568da4f7dea97ac", size = 45404, upload-time = "2025-05-23T11:40:36.113Z" },
+    { url = "https://files.pythonhosted.org/packages/87/51/d30a4aadab8670ed9d40df4982bc06c891ee1da5cdd88d16a74e1ecbd520/hiredis-3.2.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c9a592a49b7b8497e4e62c3ff40700d0c7f1a42d145b71e3e23c385df573c964", size = 43301, upload-time = "2025-05-23T11:40:37.557Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/7b/2c613e1bb5c2e2bac36e8befeefdd58b42816befb17e26ab600adfe337fb/hiredis-3.2.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0079ef1e03930b364556b78548e67236ab3def4e07e674f6adfc52944aa972dd", size = 172486, upload-time = "2025-05-23T11:40:38.659Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/df/8f2c4fcc28d6f5178b25ee1ba2157cc473f9908c16ce4b8e0bdd79e38b05/hiredis-3.2.1-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1d6a290ed45d9c14f4c50b6bda07afb60f270c69b5cb626fd23a4c2fde9e3da1", size = 168532, upload-time = "2025-05-23T11:40:39.843Z" },
+    { url = "https://files.pythonhosted.org/packages/88/ae/d0864ffaa0461e29a6940a11c858daf78c99476c06ed531b41ad2255ec25/hiredis-3.2.1-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:79dd5fe8c0892769f82949adeb021342ca46871af26e26945eb55d044fcdf0d0", size = 183216, upload-time = "2025-05-23T11:40:41.005Z" },
+    { url = "https://files.pythonhosted.org/packages/75/17/558e831b77692d73f5bcf8b493ab3eace9f11b0aa08839cdbb87995152c7/hiredis-3.2.1-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:998a82281a159f4aebbfd4fb45cfe24eb111145206df2951d95bc75327983b58", size = 172689, upload-time = "2025-05-23T11:40:42.153Z" },
+    { url = "https://files.pythonhosted.org/packages/35/b9/4fccda21f930f08c5072ad51e825d85d457748138443d7b510afe77b8264/hiredis-3.2.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:41fc3cd52368ffe7c8e489fb83af5e99f86008ed7f9d9ba33b35fec54f215c0a", size = 173319, upload-time = "2025-05-23T11:40:43.328Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/8b/596d613588b0a3c58dfcf9a17edc6a886c4de6a3096e27c7142a94e2304d/hiredis-3.2.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:8d10df3575ce09b0fa54b8582f57039dcbdafde5de698923a33f601d2e2a246c", size = 166695, upload-time = "2025-05-23T11:40:44.453Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/5b/6a1c266e9f6627a8be1fa0d8622e35e35c76ae40cce6d1c78a7e6021184a/hiredis-3.2.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:1ab010d04be33735ad8e643a40af0d68a21d70a57b1d0bff9b6a66b28cca9dbf", size = 165181, upload-time = "2025-05-23T11:40:45.697Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/70/a9b91fa70d21763d9dfd1c27ddd378f130749a0ae4a0645552f754b3d1fc/hiredis-3.2.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:ec3b5f9ea34f70aaba3e061cbe1fa3556fea401d41f5af321b13e326792f3017", size = 177589, upload-time = "2025-05-23T11:40:46.903Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/c7/31bbb015156dc4441f6e19daa9598266a61445bf3f6e14c44292764638f6/hiredis-3.2.1-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:158dfb505fff6bffd17f823a56effc0c2a7a8bc4fb659d79a52782f22eefc697", size = 169883, upload-time = "2025-05-23T11:40:48.111Z" },
+    { url = "https://files.pythonhosted.org/packages/89/44/cddc23379e0ce20ad7514b2adb2aa2c9b470ffb1ca0a2d8c020748962a22/hiredis-3.2.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9d632cd0ddd7895081be76748e6fb9286f81d2a51c371b516541c6324f2fdac9", size = 167585, upload-time = "2025-05-23T11:40:49.208Z" },
+    { url = "https://files.pythonhosted.org/packages/48/92/8fc9b981ed01fc2bbac463a203455cd493482b749801bb555ebac72923f1/hiredis-3.2.1-cp313-cp313-win32.whl", hash = "sha256:e9726d03e7df068bf755f6d1ecc61f7fc35c6b20363c7b1b96f39a14083df940", size = 20554, upload-time = "2025-05-23T11:40:50.314Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/6e/e76341d68aa717a705a2ee3be6da9f4122a0d1e3f3ad93a7104ed7a81bea/hiredis-3.2.1-cp313-cp313-win_amd64.whl", hash = "sha256:b5b1653ad7263a001f2e907e81a957d6087625f9700fa404f1a2268c0a4f9059", size = 22136, upload-time = "2025-05-23T11:40:51.497Z" },
+]
+
+[[package]]
 name = "hoyo-buddy"
 version = "1.16.7"
 source = { virtual = "." }
@@ -808,6 +846,7 @@ dependencies = [
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "python-dotenv" },
+    { name = "redis", extra = ["hiredis"] },
     { name = "sentry-sdk" },
     { name = "seria-library", extra = ["files"] },
     { name = "toml" },
@@ -851,6 +890,7 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.8.2" },
     { name = "pydantic-settings", specifier = ">=2.7.1" },
     { name = "python-dotenv", specifier = ">=1.0.1" },
+    { name = "redis", extras = ["hiredis"], specifier = ">=6.2.0" },
     { name = "sentry-sdk", specifier = ">=2.13.0" },
     { name = "seria-library", extras = ["files"], specifier = ">=1.5.4" },
     { name = "toml", specifier = ">=0.10.2" },
@@ -1558,6 +1598,20 @@ wheels = [
 [package.optional-dependencies]
 pil = [
     { name = "pillow" },
+]
+
+[[package]]
+name = "redis"
+version = "6.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ea/9a/0551e01ba52b944f97480721656578c8a7c46b51b99d66814f85fe3a4f3e/redis-6.2.0.tar.gz", hash = "sha256:e821f129b75dde6cb99dd35e5c76e8c49512a5a0d8dfdc560b2fbd44b85ca977", size = 4639129, upload-time = "2025-05-28T05:01:18.91Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/67/e60968d3b0e077495a8fee89cf3f2373db98e528288a48f1ee44967f6e8c/redis-6.2.0-py3-none-any.whl", hash = "sha256:c8ddf316ee0aab65f04a11229e94a64b2618451dab7a67cb2f77eb799d872d5e", size = 278659, upload-time = "2025-05-28T05:01:16.955Z" },
+]
+
+[package.optional-dependencies]
+hiredis = [
+    { name = "hiredis" },
 ]
 
 [[package]]


### PR DESCRIPTION
This resolves #377, quoting: "Currently all images are downloaded into separate folders in .static, this is inefficient as duplicated images are very likely to show up."

This PR also adds redis image caching for opened images.