### PR TITLE
Added Support for Enka.Network UIDs for ZZZ Character and Team Cards

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 __pycache__/
 *.py[cod]
 *$py.class
+.DS_Store
 
 # C extensions
 *.so

--- a/hoyo_buddy/bot/bot.py
+++ b/hoyo_buddy/bot/bot.py
@@ -17,7 +17,7 @@ import psutil
 from discord import app_commands
 from discord.ext import commands
 from loguru import logger
-from seria.utils import write_json  # pyright: ignore[reportMissingImports]
+from seria.utils import write_json
 
 from hoyo_buddy.bot.error_handler import get_error_embed
 from hoyo_buddy.commands.configs import COMMANDS

--- a/hoyo_buddy/bot/bot.py
+++ b/hoyo_buddy/bot/bot.py
@@ -17,7 +17,7 @@ import psutil
 from discord import app_commands
 from discord.ext import commands
 from loguru import logger
-from seria.utils import write_json
+from seria.utils import write_json  # pyright: ignore[reportMissingImports]
 
 from hoyo_buddy.bot.error_handler import get_error_embed
 from hoyo_buddy.commands.configs import COMMANDS

--- a/hoyo_buddy/cogs/profile.py
+++ b/hoyo_buddy/cogs/profile.py
@@ -207,6 +207,7 @@ class Profile(
         account: app_commands.Transform[
             HoyoAccount | None, HoyoAccountTransformer(COMMANDS["profile zzz"].games)
         ] = None,
+        uid: app_commands.Range[str, 9, 10] | None = None,
         character_id1: str | None = None,
         character_id2: str | None = None,
         character_id3: str | None = None,
@@ -216,6 +217,7 @@ class Profile(
             Game.ZZZ,
             user=user,
             account=account,
+            uid=uid,
             character_id1=character_id1,
             character_id2=character_id2,
             character_id3=character_id3,

--- a/hoyo_buddy/cogs/profile.py
+++ b/hoyo_buddy/cogs/profile.py
@@ -207,7 +207,7 @@ class Profile(
         account: app_commands.Transform[
             HoyoAccount | None, HoyoAccountTransformer(COMMANDS["profile zzz"].games)
         ] = None,
-        uid: app_commands.Range[str, 9, 10] | None = None,
+        uid: app_commands.Range[str, 8, 10] | None = None,
         character_id1: str | None = None,
         character_id2: str | None = None,
         character_id3: str | None = None,

--- a/hoyo_buddy/commands/profile.py
+++ b/hoyo_buddy/commands/profile.py
@@ -139,15 +139,13 @@ class ProfileCommand:
         zzz_data: Sequence[ZZZPartialAgent] | None = None
         zzz_user: RecordCard | None = None
 
-        enka_client = enka.zzz.ZZZClient()
-        await enka_client.start()
         try:
-            enka_data = await enka_client.fetch_showcase(self._uid)
+            async with enka.zzz.ZZZClient() as enka_client:
+                enka_data = await enka_client.fetch_showcase(self._uid)
         except enka.errors.EnkaAPIError:
             if self._account is None:
                 # enka fails and no hoyolab account provided, raise error
                 raise
-        await enka_client.close()
 
         if self._account is not None:
             client = self._account.client

--- a/hoyo_buddy/commands/profile.py
+++ b/hoyo_buddy/commands/profile.py
@@ -7,16 +7,20 @@ from genshin import GenshinException
 
 from hoyo_buddy.draw.card_data import CARD_DATA
 
-from ..exceptions import InvalidQueryError
 from ..hoyo.clients.enka.gi import EnkaGIClient
 from ..hoyo.clients.enka.hsr import EnkaHSRClient
 from ..ui.hoyo.profile.view import ProfileView
 
 if TYPE_CHECKING:
-    import discord
-    from genshin.models import PartialGenshinUserStats, StarRailUserStats, ZZZPartialAgent, RecordCard
-
     from collections.abc import Sequence
+
+    import discord
+    from genshin.models import (
+        PartialGenshinUserStats,
+        RecordCard,
+        StarRailUserStats,
+        ZZZPartialAgent,
+    )
 
     from hoyo_buddy.db import HoyoAccount
     from hoyo_buddy.enums import Locale
@@ -153,7 +157,9 @@ class ProfileCommand:
             try:
                 if enka_data is None:
                     record_cards = await client.get_record_cards()
-                    zzz_user = next((card for card in record_cards if card.uid == self._account.uid), None)
+                    zzz_user = next(
+                        (card for card in record_cards if card.uid == self._account.uid), None
+                    )
                 zzz_data = await client.get_zzz_agents()
             except GenshinException:
                 if enka_data is None:

--- a/hoyo_buddy/config.py
+++ b/hoyo_buddy/config.py
@@ -40,7 +40,7 @@ class Config(BaseSettings):
     deployment: Deployment = "main"
 
     model_config = SettingsConfigDict(
-        env_file=".env", env_file_encoding="utf-8", cli_parse_args=True, cli_implicit_flags=True
+        env_file=".env", env_file_encoding="utf-8", cli_parse_args=False, cli_implicit_flags=True
     )
 
     @property

--- a/hoyo_buddy/config.py
+++ b/hoyo_buddy/config.py
@@ -28,7 +28,7 @@ class Config(BaseSettings):
     sentry_dsn: str | None = None
     db_url: str
     fernet_key: str
-    proxy: str | None = None
+    proxy: str
     redis_url: str | None = None
 
     # Command-line arguments

--- a/hoyo_buddy/config.py
+++ b/hoyo_buddy/config.py
@@ -28,7 +28,7 @@ class Config(BaseSettings):
     sentry_dsn: str | None = None
     db_url: str
     fernet_key: str
-    proxy: str
+    proxy: str | None = None
     redis_url: str | None = None
 
     # Command-line arguments

--- a/hoyo_buddy/constants.py
+++ b/hoyo_buddy/constants.py
@@ -525,11 +525,7 @@ ZZZ_AVATAR_BATTLE_TEMP_JSON = "zzz_avatar_battle_temp.json"
 
 ZZZ_AGENT_CORE_LEVEL_MAP = {1: "0", 2: "A", 3: "B", 4: "C", 5: "D", 6: "E", 7: "F"}
 
-ZZZ_RARITY_NUM_TO_RARITY = {
-    4: 'S',
-    3: 'A',
-    2: 'B'
-}
+ZZZ_RARITY_NUM_TO_RARITY = {4: "S", 3: "A", 2: "B"}
 
 LOCALE_TO_ZENLESS_DATA_LANG: dict[Locale, str] = {
     Locale.taiwan_chinese: "CHT",
@@ -592,23 +588,19 @@ LOCALE_TO_STARRAIL_DATA_LANG: dict[Locale, str] = {
 ZZZ_ENKA_STAT_TO_GPY_ZZZ_PROPERTY = {
     enka.zzz.StatType.CRIT_RATE_FLAT: genshin.models.ZZZPropertyType.CRIT_RATE,
     enka.zzz.StatType.CRIT_DMG_FLAT: genshin.models.ZZZPropertyType.CRIT_DMG,
-
     enka.zzz.StatType.ANOMALY_PRO_FLAT: genshin.models.ZZZPropertyType.ANOMALY_PROFICIENCY,
     enka.zzz.StatType.ANOMALY_MASTERY_PERCENT: genshin.models.ZZZPropertyType.ANOMALY_MASTERY,
     enka.zzz.StatType.ENERGY_REGEN_PERCENT: genshin.models.ZZZPropertyType.ENERGY_REGEN,
     enka.zzz.StatType.IMPACT_PERCENT: genshin.models.ZZZPropertyType.IMPACT,
-
     enka.zzz.StatType.ATK_BASE: genshin.models.ZZZPropertyType.BASE_ATK,
     enka.zzz.StatType.HP_FLAT: genshin.models.ZZZPropertyType.FLAT_HP,
     enka.zzz.StatType.ATK_FLAT: genshin.models.ZZZPropertyType.FLAT_ATK,
     enka.zzz.StatType.DEF_FLAT: genshin.models.ZZZPropertyType.FLAT_DEF,
     enka.zzz.StatType.PEN_FLAT: genshin.models.ZZZPropertyType.FLAT_PEN,
-
     enka.zzz.StatType.HP_PERCENT: genshin.models.ZZZPropertyType.HP_PERCENT,
     enka.zzz.StatType.ATK_PERCENT: genshin.models.ZZZPropertyType.ATK_PERCENT,
     enka.zzz.StatType.DEF_PERCENT: genshin.models.ZZZPropertyType.DEF_PERCENT,
     enka.zzz.StatType.PEN_RATIO_FLAT: genshin.models.ZZZPropertyType.PEN_PERCENT,
-
     enka.zzz.StatType.PHYSICAL_DMG_BONUS_FLAT: genshin.models.ZZZPropertyType.DISC_PHYSICAL_DMG_BONUS,
     enka.zzz.StatType.FIRE_DMG_BONUS_FLAT: genshin.models.ZZZPropertyType.DISC_FIRE_DMG_BONUS,
     enka.zzz.StatType.ICE_DMG_BONUS_FLAT: genshin.models.ZZZPropertyType.DISC_ICE_DMG_BONUS,
@@ -622,7 +614,7 @@ ZZZ_ENKA_PROFESSION_TO_GPY_ZZZSPECIALTY = {
     enka.zzz.ProfessionType.ANOMALY: genshin.models.ZZZSpecialty.ANOMALY,
     enka.zzz.ProfessionType.SUPPORT: genshin.models.ZZZSpecialty.SUPPORT,
     enka.zzz.ProfessionType.DEFENSE: genshin.models.ZZZSpecialty.DEFENSE,
-    enka.zzz.ProfessionType.RUPTURE: genshin.models.ZZZSpecialty.RUPTURE
+    enka.zzz.ProfessionType.RUPTURE: genshin.models.ZZZSpecialty.RUPTURE,
 }
 
 ZZZ_ENKA_SKILLTYPE_TO_GPY_SKILLTYPE = {
@@ -632,6 +624,16 @@ ZZZ_ENKA_SKILLTYPE_TO_GPY_SKILLTYPE = {
     enka.zzz.SkillType.SPECIAL_ATK: genshin.models.ZZZSkillType.SPECIAL_ATTACK,
     enka.zzz.SkillType.ULTIMATE: genshin.models.ZZZSkillType.CHAIN_ATTACK,
     enka.zzz.SkillType.CORE_SKILL: genshin.models.ZZZSkillType.CORE_SKILL,
+}
+
+ZZZ_ENKA_ELEMENT_TO_ZZZELEMENTTYPE = {
+    enka.zzz.Element.PHYSICAL: genshin.models.ZZZElementType.PHYSICAL,
+    enka.zzz.Element.FIRE: genshin.models.ZZZElementType.FIRE,
+    enka.zzz.Element.ICE: genshin.models.ZZZElementType.ICE,
+    enka.zzz.Element.ELECTRIC: genshin.models.ZZZElementType.ELECTRIC,
+    enka.zzz.Element.ETHER: genshin.models.ZZZElementType.ETHER,
+    enka.zzz.Element.FIRE_FROST: genshin.models.ZZZElementType.ICE,  # Miyabi element
+    enka.zzz.Element.AURIC_ETHER: genshin.models.ZZZElementType.ETHER,  # Yi Xuan element
 }
 
 

--- a/hoyo_buddy/constants.py
+++ b/hoyo_buddy/constants.py
@@ -30,6 +30,7 @@ from .enums import (
 )
 
 if TYPE_CHECKING:
+    from hoyo_buddy.models import ZZZStat
     from hoyo_buddy.types import AutoTaskType, OpenGameGame, OpenGameRegion, SleepTime
 
 
@@ -525,7 +526,7 @@ ZZZ_AVATAR_BATTLE_TEMP_JSON = "zzz_avatar_battle_temp.json"
 
 ZZZ_AGENT_CORE_LEVEL_MAP = {1: "0", 2: "A", 3: "B", 4: "C", 5: "D", 6: "E", 7: "F"}
 
-ZZZ_RARITY_NUM_TO_RARITY = {4: "S", 3: "A", 2: "B"}
+ZZZ_RARITY_NUM_TO_RARITY: dict[int, Literal["B", "A", "S"]] = {4: "S", 3: "A", 2: "B"}
 
 LOCALE_TO_ZENLESS_DATA_LANG: dict[Locale, str] = {
     Locale.taiwan_chinese: "CHT",
@@ -606,15 +607,6 @@ ZZZ_ENKA_STAT_TO_GPY_ZZZ_PROPERTY = {
     enka.zzz.StatType.ICE_DMG_BONUS_FLAT: genshin.models.ZZZPropertyType.DISC_ICE_DMG_BONUS,
     enka.zzz.StatType.ELECTRIC_DMG_BONUS_FLAT: genshin.models.ZZZPropertyType.DISC_ELECTRIC_DMG_BONUS,
     enka.zzz.StatType.ETHER_DMG_BONUS_FLAT: genshin.models.ZZZPropertyType.DISC_ETHER_DMG_BONUS,
-}
-
-ZZZ_ENKA_PROFESSION_TO_GPY_ZZZSPECIALTY = {
-    enka.zzz.ProfessionType.STUN: genshin.models.ZZZSpecialty.STUN,
-    enka.zzz.ProfessionType.ATTACK: genshin.models.ZZZSpecialty.ATTACK,
-    enka.zzz.ProfessionType.ANOMALY: genshin.models.ZZZSpecialty.ANOMALY,
-    enka.zzz.ProfessionType.SUPPORT: genshin.models.ZZZSpecialty.SUPPORT,
-    enka.zzz.ProfessionType.DEFENSE: genshin.models.ZZZSpecialty.DEFENSE,
-    enka.zzz.ProfessionType.RUPTURE: genshin.models.ZZZSpecialty.RUPTURE,
 }
 
 ZZZ_ENKA_SKILLTYPE_TO_GPY_SKILLTYPE = {
@@ -838,7 +830,7 @@ DISC_SUBSTAT_VALUES: dict[Literal["B", "A", "S"], dict[genshin.models.ZZZPropert
 
 
 def get_disc_substat_roll_num(
-    disc_rarity: Literal["B", "A", "S"], prop: genshin.models.ZZZProperty
+    disc_rarity: Literal["B", "A", "S"], prop: genshin.models.ZZZProperty | ZZZStat
 ) -> int:
     if not isinstance(prop.type, genshin.models.ZZZPropertyType):
         return 0

--- a/hoyo_buddy/constants.py
+++ b/hoyo_buddy/constants.py
@@ -5,6 +5,9 @@ import os
 import pathlib
 from typing import TYPE_CHECKING, Final, Literal
 
+import enka.enums
+import enka.enums.zzz
+
 import akasha
 import ambr
 import enka
@@ -525,6 +528,12 @@ ZZZ_AVATAR_BATTLE_TEMP_JSON = "zzz_avatar_battle_temp.json"
 
 ZZZ_AGENT_CORE_LEVEL_MAP = {1: "0", 2: "A", 3: "B", 4: "C", 5: "D", 6: "E", 7: "F"}
 
+ZZZ_RARITY_NUM_TO_RARITY = {
+    4: 'S',
+    3: 'A',
+    2: 'B'
+}
+
 LOCALE_TO_ZENLESS_DATA_LANG: dict[Locale, str] = {
     Locale.taiwan_chinese: "CHT",
     Locale.german: "DE",
@@ -581,6 +590,51 @@ LOCALE_TO_STARRAIL_DATA_LANG: dict[Locale, str] = {
     Locale.russian: "RU",
     Locale.thai: "TH",
     Locale.vietnamese: "VI",
+}
+
+ZZZ_ENKA_STAT_TO_GPY_ZZZ_PROPERTY = {
+    enka.zzz.StatType.CRIT_DMG_FLAT: genshin.models.ZZZPropertyType.CRIT_RATE,
+    enka.zzz.StatType.CRIT_DMG_FLAT: genshin.models.ZZZPropertyType.CRIT_DMG,
+
+    enka.zzz.StatType.ANOMALY_PRO_FLAT: genshin.models.ZZZPropertyType.ANOMALY_PROFICIENCY,
+    enka.zzz.StatType.ANOMALY_MASTERY_PERCENT: genshin.models.ZZZPropertyType.ANOMALY_MASTERY,
+    enka.zzz.StatType.ENERGY_REGEN_PERCENT: genshin.models.ZZZPropertyType.ENERGY_REGEN,
+    enka.zzz.StatType.IMPACT_PERCENT: genshin.models.ZZZPropertyType.IMPACT,
+
+    enka.zzz.StatType.ATK_BASE: genshin.models.ZZZPropertyType.BASE_ATK,
+    enka.zzz.StatType.HP_FLAT: genshin.models.ZZZPropertyType.FLAT_HP,
+    enka.zzz.StatType.ATK_FLAT: genshin.models.ZZZPropertyType.FLAT_ATK,
+    enka.zzz.StatType.DEF_FLAT: genshin.models.ZZZPropertyType.FLAT_DEF,
+    enka.zzz.StatType.PEN_FLAT: genshin.models.ZZZPropertyType.FLAT_PEN,
+
+    enka.zzz.StatType.HP_PERCENT: genshin.models.ZZZPropertyType.HP_PERCENT,
+    enka.zzz.StatType.ATK_PERCENT: genshin.models.ZZZPropertyType.ATK_PERCENT,
+    enka.zzz.StatType.DEF_PERCENT: genshin.models.ZZZPropertyType.DEF_PERCENT,
+    enka.zzz.StatType.PEN_RATIO_FLAT: genshin.models.ZZZPropertyType.PEN_PERCENT,
+
+    enka.zzz.StatType.PHYSICAL_DMG_BONUS_FLAT: genshin.models.ZZZPropertyType.DISC_PHYSICAL_DMG_BONUS,
+    enka.zzz.StatType.FIRE_DMG_BONUS_FLAT: genshin.models.ZZZPropertyType.DISC_FIRE_DMG_BONUS,
+    enka.zzz.StatType.ICE_DMG_BONUS_FLAT: genshin.models.ZZZPropertyType.DISC_ICE_DMG_BONUS,
+    enka.zzz.StatType.ELECTRIC_DMG_BONUS_FLAT: genshin.models.ZZZPropertyType.DISC_ELECTRIC_DMG_BONUS,
+    enka.zzz.StatType.ETHER_DMG_BONUS_FLAT: genshin.models.ZZZPropertyType.DISC_ETHER_DMG_BONUS,
+}
+
+ZZZ_ENKA_PROFESSION_TO_GPY_ZZZSPECIALTY = {
+    enka.zzz.ProfessionType.STUN: genshin.models.ZZZSpecialty.STUN,
+    enka.zzz.ProfessionType.ATTACK: genshin.models.ZZZSpecialty.ATTACK,
+    enka.zzz.ProfessionType.ANOMALY: genshin.models.ZZZSpecialty.ANOMALY,
+    enka.zzz.ProfessionType.SUPPORT: genshin.models.ZZZSpecialty.SUPPORT,
+    enka.zzz.ProfessionType.DEFENSE: genshin.models.ZZZSpecialty.DEFENSE,
+    enka.zzz.ProfessionType.RUPTURE: genshin.models.ZZZSpecialty.RUPTURE
+}
+
+ZZZ_ENKA_SKILLTYPE_TO_GPY_SKILLTYPE = {
+    enka.zzz.SkillType.BASIC_ATK: genshin.models.ZZZSkillType.BASIC_ATTACK,
+    enka.zzz.SkillType.DASH: genshin.models.ZZZSkillType.DODGE,
+    enka.zzz.SkillType.ASSIST: genshin.models.ZZZSkillType.ASSIST,
+    enka.zzz.SkillType.SPECIAL_ATK: genshin.models.ZZZSkillType.SPECIAL_ATTACK,
+    enka.zzz.SkillType.ULTIMATE: genshin.models.ZZZSkillType.CHAIN_ATTACK,
+    enka.zzz.SkillType.CORE_SKILL: genshin.models.ZZZSkillType.CORE_SKILL,
 }
 
 

--- a/hoyo_buddy/constants.py
+++ b/hoyo_buddy/constants.py
@@ -5,9 +5,6 @@ import os
 import pathlib
 from typing import TYPE_CHECKING, Final, Literal
 
-import enka.enums
-import enka.enums.zzz
-
 import akasha
 import ambr
 import enka
@@ -593,7 +590,7 @@ LOCALE_TO_STARRAIL_DATA_LANG: dict[Locale, str] = {
 }
 
 ZZZ_ENKA_STAT_TO_GPY_ZZZ_PROPERTY = {
-    enka.zzz.StatType.CRIT_DMG_FLAT: genshin.models.ZZZPropertyType.CRIT_RATE,
+    enka.zzz.StatType.CRIT_RATE_FLAT: genshin.models.ZZZPropertyType.CRIT_RATE,
     enka.zzz.StatType.CRIT_DMG_FLAT: genshin.models.ZZZPropertyType.CRIT_DMG,
 
     enka.zzz.StatType.ANOMALY_PRO_FLAT: genshin.models.ZZZPropertyType.ANOMALY_PROFICIENCY,

--- a/hoyo_buddy/constants.py
+++ b/hoyo_buddy/constants.py
@@ -636,6 +636,28 @@ ZZZ_ENKA_ELEMENT_TO_ZZZELEMENTTYPE = {
     enka.zzz.Element.AURIC_ETHER: genshin.models.ZZZElementType.ETHER,  # Yi Xuan element
 }
 
+ZZZ_ENKA_AGENT_STAT_TYPE_TO_ZZZ_AGENT_PROPERTY = {
+    enka.zzz.AgentStatType.MAX_HP: genshin.models.ZZZPropertyType.AGENT_HP,
+    enka.zzz.AgentStatType.ATK: genshin.models.ZZZPropertyType.AGENT_ATK,
+    enka.zzz.AgentStatType.DEF: genshin.models.ZZZPropertyType.AGENT_DEF,
+    enka.zzz.AgentStatType.IMPACT: genshin.models.ZZZPropertyType.AGENT_IMPACT,
+    enka.zzz.AgentStatType.CRIT_RATE: genshin.models.ZZZPropertyType.AGENT_CRIT_RATE,
+    enka.zzz.AgentStatType.CRIT_DMG: genshin.models.ZZZPropertyType.AGENT_CRIT_DMG,
+    enka.zzz.AgentStatType.ANOMALY_PROFICIENCY: genshin.models.ZZZPropertyType.ANOMALY_PROFICIENCY,
+    enka.zzz.AgentStatType.ANOMALY_MASTERY: genshin.models.ZZZPropertyType.ANOMALY_MASTERY,
+    enka.zzz.AgentStatType.PEN_RATIO: genshin.models.ZZZPropertyType.AGENT_PEN_RATIO,
+    enka.zzz.AgentStatType.PEN: genshin.models.ZZZPropertyType.AGENT_PEN,
+    enka.zzz.AgentStatType.ENERGY_REGEN: genshin.models.ZZZPropertyType.AGENT_ENERGY_GEN,
+    enka.zzz.AgentStatType.SHEER_FORCE: genshin.models.ZZZPropertyType.AGENT_SHEER_FORCE,
+    enka.zzz.AgentStatType.AAA: genshin.models.ZZZPropertyType.AGENT_ADRENALINE,
+    enka.zzz.AgentStatType.PHYSICAL_DMG_BONUS: genshin.models.ZZZPropertyType.PHYSICAL_DMG_BONUS,
+    enka.zzz.AgentStatType.FIRE_DMG_BONUS: genshin.models.ZZZPropertyType.FIRE_DMG_BONUS,
+    enka.zzz.AgentStatType.ICE_DMG_BONUS: genshin.models.ZZZPropertyType.ICE_DMG_BONUS,
+    enka.zzz.AgentStatType.ELECTRIC_DMG_BONUS: genshin.models.ZZZPropertyType.ELECTRIC_DMG_BONUS,
+    enka.zzz.AgentStatType.ETHER_DMG_BONUS: genshin.models.ZZZPropertyType.ETHER_DMG_BONUS,
+    enka.zzz.AgentStatType.SHEER_DMG_BONUS: genshin.models.ZZZPropertyType.ETHER_DMG_BONUS,  # for yi xuan?
+}
+
 
 def locale_to_starrail_data_lang(locale: Locale) -> str:
     return LOCALE_TO_STARRAIL_DATA_LANG.get(locale, "EN")

--- a/hoyo_buddy/draw/funcs/hoyo/zzz/build_card.py
+++ b/hoyo_buddy/draw/funcs/hoyo/zzz/build_card.py
@@ -17,13 +17,13 @@ from .common import SKILL_ORDER, STAT_ICONS, get_props
 if TYPE_CHECKING:
     from io import BytesIO
 
-    from hoyo_buddy.models import AgentNameData
+    from hoyo_buddy.models import AgentNameData, ZZZEnkaCharacter
 
 
 class ZZZAgentCard:
     def __init__(
         self,
-        agent: ZZZFullAgent,
+        agent: ZZZFullAgent | ZZZEnkaCharacter,
         *,
         locale: str,
         image_url: str,

--- a/hoyo_buddy/draw/funcs/hoyo/zzz/build_card4.py
+++ b/hoyo_buddy/draw/funcs/hoyo/zzz/build_card4.py
@@ -16,13 +16,13 @@ from hoyo_buddy.l10n import LocaleStr
 if TYPE_CHECKING:
     from io import BytesIO
 
-    from hoyo_buddy.models import AgentNameData
+    from hoyo_buddy.models import AgentNameData, ZZZEnkaCharacter
 
 
 class ZZZAgentCard4:
     def __init__(
         self,
-        agent: ZZZFullAgent,
+        agent: ZZZFullAgent | ZZZEnkaCharacter,
         *,
         locale: Locale,
         image_url: str,

--- a/hoyo_buddy/draw/funcs/hoyo/zzz/characters.py
+++ b/hoyo_buddy/draw/funcs/hoyo/zzz/characters.py
@@ -10,6 +10,7 @@ from PIL import Image, ImageDraw
 from hoyo_buddy.constants import ZZZ_AGENT_CORE_LEVEL_MAP
 from hoyo_buddy.draw.drawer import WHITE, Drawer
 from hoyo_buddy.l10n import LevelStr
+from hoyo_buddy.models import ZZZEnkaCharacter
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -20,7 +21,7 @@ if TYPE_CHECKING:
 
 
 def draw_agent_small_card(
-    agent: ZZZFullAgent | UnownedZZZCharacter,
+    agent: ZZZFullAgent | ZZZEnkaCharacter | UnownedZZZCharacter,
     *,
     dark_mode: bool,
     locale: Locale,
@@ -60,7 +61,7 @@ def draw_agent_small_card(
 
     # W-engine
     im.paste(engine_block, (588, 45), engine_block)
-    if isinstance(agent, ZZZFullAgent) and agent.w_engine is not None:
+    if isinstance(agent, ZZZFullAgent | ZZZEnkaCharacter) and agent.w_engine is not None:
         icon = drawer.open_static(agent.w_engine.icon, size=(268, 268))
         im.paste(icon, (593, 49), icon)
 
@@ -76,7 +77,7 @@ def draw_agent_small_card(
 
     # Skill
     im.paste(skill_bar, (457, 362), skill_bar)
-    if isinstance(agent, ZZZFullAgent):
+    if isinstance(agent, ZZZFullAgent | ZZZEnkaCharacter):
         skill_order = (
             ZZZSkillType.BASIC_ATTACK,
             ZZZSkillType.DODGE,
@@ -111,7 +112,9 @@ def draw_agent_small_card(
 
 
 def draw_big_agent_card(
-    agents: Sequence[ZZZFullAgent | UnownedZZZCharacter], dark_mode: bool, locale: Locale
+    agents: Sequence[ZZZFullAgent | ZZZEnkaCharacter | UnownedZZZCharacter],
+    dark_mode: bool,
+    locale: Locale,
 ) -> BytesIO:
     asset_path = "hoyo-buddy-assets/assets/zzz-characters"
     theme = "dark" if dark_mode else "light"

--- a/hoyo_buddy/draw/funcs/hoyo/zzz/common.py
+++ b/hoyo_buddy/draw/funcs/hoyo/zzz/common.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Final
+from typing import TYPE_CHECKING, Final
 
 from discord import utils as dutils
 from genshin.models import (
@@ -12,6 +12,9 @@ from genshin.models import (
 )
 
 from hoyo_buddy.enums import Locale
+
+if TYPE_CHECKING:
+    from hoyo_buddy.models import ZZZEnkaCharacter
 
 STAT_ICONS: Final[dict[ZZZPropertyType, str]] = {
     # Disc and w-engine
@@ -82,7 +85,9 @@ PEN_NAME: Final[dict[Locale, str]] = {
 }
 
 
-def get_props(agent: ZZZFullAgent, *, locale: Locale | None = None) -> list[ZZZAgentProperty]:
+def get_props(
+    agent: ZZZFullAgent | ZZZEnkaCharacter, *, locale: Locale | None = None
+) -> list[ZZZAgentProperty]:
     pen = dutils.get(agent.properties, type=ZZZPropertyType.AGENT_PEN)
     if pen is None:
         # Calculate flat pen from discs

--- a/hoyo_buddy/draw/funcs/hoyo/zzz/team_card.py
+++ b/hoyo_buddy/draw/funcs/hoyo/zzz/team_card.py
@@ -129,7 +129,9 @@ class ZZZTeamCard:
 
         return im
 
-    def _draw_disc_drives(self, agent: ZZZFullAgent | ZZZEnkaCharacter, im: Image.Image, drawer: Drawer) -> None:
+    def _draw_disc_drives(
+        self, agent: ZZZFullAgent | ZZZEnkaCharacter, im: Image.Image, drawer: Drawer
+    ) -> None:
         start_pos = (926, 21)
         y_diff = 94
         disc_mask = drawer.open_asset("disc_mask.png")
@@ -259,7 +261,9 @@ class ZZZTeamCard:
             drawer.write(text, size=26, position=start_pos, style="bold", anchor="mm")
             start_pos = (669, 214 + 53) if i == 2 else (start_pos[0] + 99, start_pos[1])
 
-    def _draw_w_engine(self, agent: ZZZFullAgent | ZZZEnkaCharacter, im: Image.Image, drawer: Drawer) -> None:
+    def _draw_w_engine(
+        self, agent: ZZZFullAgent | ZZZEnkaCharacter, im: Image.Image, drawer: Drawer
+    ) -> None:
         engine = agent.w_engine
         assert engine is not None
 
@@ -310,7 +314,9 @@ class ZZZTeamCard:
             text, size=16, position=(849, 140), anchor="mm", style="bold_italic", color=WHITE
         )
 
-    def _draw_stats(self, agent: ZZZFullAgent | ZZZEnkaCharacter, im: Image.Image, drawer: Drawer) -> None:
+    def _draw_stats(
+        self, agent: ZZZFullAgent | ZZZEnkaCharacter, im: Image.Image, drawer: Drawer
+    ) -> None:
         props = get_props(agent)
         start_pos = (299, 31)
         agent_color = self._agent_colors[agent.id]

--- a/hoyo_buddy/draw/funcs/hoyo/zzz/team_card.py
+++ b/hoyo_buddy/draw/funcs/hoyo/zzz/team_card.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
 
     from genshin.models import ZZZFullAgent
 
-    from hoyo_buddy.models import AgentNameData
+    from hoyo_buddy.models import AgentNameData, ZZZEnkaCharacter
 
 
 class ZZZTeamCard:
@@ -27,7 +27,7 @@ class ZZZTeamCard:
         self,
         *,
         locale: str,
-        agents: Sequence[ZZZFullAgent],
+        agents: Sequence[ZZZFullAgent | ZZZEnkaCharacter],
         agent_colors: dict[int, str],
         agent_images: dict[int, str],
         name_datas: dict[int, AgentNameData],
@@ -85,7 +85,7 @@ class ZZZTeamCard:
 
         return card
 
-    def _draw_agent_card(self, agent: ZZZFullAgent) -> Image.Image:
+    def _draw_agent_card(self, agent: ZZZFullAgent | ZZZEnkaCharacter) -> Image.Image:
         im = self._draw_card(
             image_url=self._agent_images[agent.id],
             blob_color=Drawer.hex_to_rgb(self._agent_colors[agent.id]),
@@ -129,7 +129,7 @@ class ZZZTeamCard:
 
         return im
 
-    def _draw_disc_drives(self, agent: ZZZFullAgent, im: Image.Image, drawer: Drawer) -> None:
+    def _draw_disc_drives(self, agent: ZZZFullAgent | ZZZEnkaCharacter, im: Image.Image, drawer: Drawer) -> None:
         start_pos = (926, 21)
         y_diff = 94
         disc_mask = drawer.open_asset("disc_mask.png")
@@ -244,7 +244,7 @@ class ZZZTeamCard:
 
             start_pos = (1132, 21) if i == 2 else (start_pos[0], start_pos[1] + y_diff)
 
-    def _draw_skill_levels(self, agent: ZZZFullAgent, drawer: Drawer) -> None:
+    def _draw_skill_levels(self, agent: ZZZFullAgent | ZZZEnkaCharacter, drawer: Drawer) -> None:
         start_pos = (669, 214)
         for i, skill_type in enumerate(SKILL_ORDER):
             skill = dutils.get(agent.skills, type=skill_type)
@@ -259,7 +259,7 @@ class ZZZTeamCard:
             drawer.write(text, size=26, position=start_pos, style="bold", anchor="mm")
             start_pos = (669, 214 + 53) if i == 2 else (start_pos[0] + 99, start_pos[1])
 
-    def _draw_w_engine(self, agent: ZZZFullAgent, im: Image.Image, drawer: Drawer) -> None:
+    def _draw_w_engine(self, agent: ZZZFullAgent | ZZZEnkaCharacter, im: Image.Image, drawer: Drawer) -> None:
         engine = agent.w_engine
         assert engine is not None
 
@@ -310,7 +310,7 @@ class ZZZTeamCard:
             text, size=16, position=(849, 140), anchor="mm", style="bold_italic", color=WHITE
         )
 
-    def _draw_stats(self, agent: ZZZFullAgent, im: Image.Image, drawer: Drawer) -> None:
+    def _draw_stats(self, agent: ZZZFullAgent | ZZZEnkaCharacter, im: Image.Image, drawer: Drawer) -> None:
         props = get_props(agent)
         start_pos = (299, 31)
         agent_color = self._agent_colors[agent.id]

--- a/hoyo_buddy/draw/main_funcs.py
+++ b/hoyo_buddy/draw/main_funcs.py
@@ -23,7 +23,7 @@ from hoyo_buddy.models import (
     UnownedHSRCharacter,
     UnownedZZZCharacter,
     ZZZDrawData,
-    ZZZEnkaCharacter
+    ZZZEnkaCharacter,
 )
 
 from .static import download_images
@@ -428,7 +428,10 @@ def _get_images_path(template: Literal[1, 2], use_m3_art: bool) -> str:
 
 
 async def fetch_zzz_draw_data(
-    agents: Sequence[ZZZFullAgent | ZZZEnkaCharacter], *, template: Literal[1, 2, 3, 4], use_m3_art: bool = False
+    agents: Sequence[ZZZFullAgent | ZZZEnkaCharacter],
+    *,
+    template: Literal[1, 2, 3, 4],
+    use_m3_art: bool = False,
 ) -> ZZZDrawData:
     name_datas_path = "zzz_name_data.json"
     name_datas: dict[int, dict[str, str]] = await JSONFile.read(name_datas_path, int_key=True)

--- a/hoyo_buddy/draw/main_funcs.py
+++ b/hoyo_buddy/draw/main_funcs.py
@@ -23,6 +23,7 @@ from hoyo_buddy.models import (
     UnownedHSRCharacter,
     UnownedZZZCharacter,
     ZZZDrawData,
+    ZZZEnkaCharacter
 )
 
 from .static import download_images
@@ -521,7 +522,7 @@ async def fetch_zzz_draw_data(
 
 async def draw_zzz_build_card(
     draw_input: DrawInput,
-    agent: ZZZFullAgent,
+    agent: ZZZFullAgent | ZZZEnkaCharacter,
     *,
     card_data: dict[str, Any],
     custom_color: str | None,

--- a/hoyo_buddy/draw/main_funcs.py
+++ b/hoyo_buddy/draw/main_funcs.py
@@ -428,7 +428,7 @@ def _get_images_path(template: Literal[1, 2], use_m3_art: bool) -> str:
 
 
 async def fetch_zzz_draw_data(
-    agents: Sequence[ZZZFullAgent], *, template: Literal[1, 2, 3, 4], use_m3_art: bool = False
+    agents: Sequence[ZZZFullAgent | ZZZEnkaCharacter], *, template: Literal[1, 2, 3, 4], use_m3_art: bool = False
 ) -> ZZZDrawData:
     name_datas_path = "zzz_name_data.json"
     name_datas: dict[int, dict[str, str]] = await JSONFile.read(name_datas_path, int_key=True)
@@ -596,12 +596,12 @@ async def draw_zzz_build_card(
 
 
 async def draw_zzz_characters_card(
-    draw_input: DrawInput, agents: Sequence[ZZZFullAgent | UnownedZZZCharacter]
+    draw_input: DrawInput, agents: Sequence[ZZZFullAgent | ZZZEnkaCharacter | UnownedZZZCharacter]
 ) -> File:
     urls: list[str] = []
     for agent in agents:
         urls.append(agent.banner_icon)
-        if isinstance(agent, ZZZFullAgent) and agent.w_engine is not None:
+        if isinstance(agent, ZZZFullAgent | ZZZEnkaCharacter) and agent.w_engine is not None:
             urls.append(agent.w_engine.icon)
 
     await download_images(urls, draw_input.session)
@@ -638,7 +638,7 @@ async def draw_honkai_suits_card(draw_input: DrawInput, suits: Sequence[FullBatt
 
 async def draw_zzz_team_card(
     draw_input: DrawInput,
-    agents: Sequence[ZZZFullAgent],
+    agents: Sequence[ZZZFullAgent | ZZZEnkaCharacter],
     agent_colors: dict[int, str],
     agent_custom_images: dict[int, str],
     show_substat_rolls: dict[int, bool],

--- a/hoyo_buddy/hoyo/clients/gpy.py
+++ b/hoyo_buddy/hoyo/clients/gpy.py
@@ -24,10 +24,11 @@ from hoyo_buddy.constants import (
     PLAYER_BOY_GACHA_ART,
     PLAYER_GIRL_GACHA_ART,
     POST_REPLIES,
-    ZZZ_RARITY_NUM_TO_RARITY,
-    ZZZ_ENKA_STAT_TO_GPY_ZZZ_PROPERTY,
+    ZZZ_ENKA_ELEMENT_TO_ZZZELEMENTTYPE,
     ZZZ_ENKA_PROFESSION_TO_GPY_ZZZSPECIALTY,
     ZZZ_ENKA_SKILLTYPE_TO_GPY_SKILLTYPE,
+    ZZZ_ENKA_STAT_TO_GPY_ZZZ_PROPERTY,
+    ZZZ_RARITY_NUM_TO_RARITY,
     contains_traveler_id,
     convert_fight_prop,
 )
@@ -356,75 +357,69 @@ class GenshinClient(ProxyGenshinClient):
             ),
             path=GPY_PATH_TO_EKNA_PATH[c.path],
         )
-    
+
     @staticmethod
-    def convert_zzz_character(
-        agent: enka.zzz.Agent,
-    ) -> models.ZZZEnkaCharacter:
+    def convert_zzz_character(agent: enka.zzz.Agent) -> models.ZZZEnkaCharacter:
         """Convert Agent from enka.zzz to ZZZEnkaCharacter that's used for drawing cards."""
         w_engine = genshin.models.WEngine(
             id=agent.w_engine.id,
             level=agent.w_engine.level,
             name=agent.w_engine.name,
             icon=agent.w_engine.icon,
-            refinement=agent.w_engine.phase,
+            star=agent.w_engine.phase,
             rarity=ZZZ_RARITY_NUM_TO_RARITY[agent.w_engine.rarity_num],
             properties=[
                 genshin.models.ZZZProperty(
                     property_name=agent.w_engine.sub_stat.name,
                     property_id=ZZZ_ENKA_STAT_TO_GPY_ZZZ_PROPERTY[agent.w_engine.sub_stat.type],
-                    base=agent.w_engine.sub_stat.formatted_value
+                    base=agent.w_engine.sub_stat.formatted_value,
                 )
             ],
             main_properties=[
                 genshin.models.ZZZProperty(
                     property_name=agent.w_engine.main_stat.name,
                     property_id=ZZZ_ENKA_STAT_TO_GPY_ZZZ_PROPERTY[agent.w_engine.main_stat.type],
-                    base=agent.w_engine.main_stat.formatted_value
+                    base=agent.w_engine.main_stat.formatted_value,
                 )
             ],
-            effect_title="",
-            effect_description="",
-            profession=ZZZ_ENKA_PROFESSION_TO_GPY_ZZZSPECIALTY[agent.w_engine.specialty]
+            talent_title="",
+            talent_content="",
+            profession=ZZZ_ENKA_PROFESSION_TO_GPY_ZZZSPECIALTY[agent.w_engine.specialty],
         )
         discs = [
             genshin.models.ZZZDisc(
                 id=disc.id,
                 level=disc.level,
-                name=disc.uid,
+                name=str(disc.uid),
                 icon="",
                 rarity=ZZZ_RARITY_NUM_TO_RARITY[disc.rarity_num],
                 main_properties=[
                     genshin.models.ZZZProperty(
-                    property_name=disc.main_stat.name,
-                    property_id=ZZZ_ENKA_STAT_TO_GPY_ZZZ_PROPERTY[disc.main_stat.type],
-                    base=disc.main_stat.formatted_value
-                )
+                        property_name=disc.main_stat.name,
+                        property_id=ZZZ_ENKA_STAT_TO_GPY_ZZZ_PROPERTY[disc.main_stat.type],
+                        base=disc.main_stat.formatted_value,
+                    )
                 ],
                 properties=[
                     genshin.models.ZZZProperty(
-                    property_name=prop.name,
-                    property_id=ZZZ_ENKA_STAT_TO_GPY_ZZZ_PROPERTY[prop.type],
-                    base=prop.formatted_value
-                ) for prop in disc.sub_stats
+                        property_name=prop.name,
+                        property_id=ZZZ_ENKA_STAT_TO_GPY_ZZZ_PROPERTY[prop.type],
+                        base=prop.formatted_value,
+                    )
+                    for prop in disc.sub_stats
                 ],
-                set_effect=genshin.models.DiscSetEffect(
-                        id=disc.set_id,
-                        name="",
-                        owned_num=0,
-                        two_piece_description="",
-                        four_piece_description=""
-                    ),
-                position=disc.slot,
-
+                equip_suit=genshin.models.DiscSetEffect(
+                    suit_id=disc.set_id, name="", own=0, desc1="", desc2=""
+                ),
+                equipment_type=disc.slot,
             )
             for disc in agent.discs
         ]
         skills = [
             genshin.models.AgentSkill(
                 level=skill.level,
-                type=ZZZ_ENKA_SKILLTYPE_TO_GPY_SKILLTYPE[skill.type],
-                items=[]
+                skill_type=ZZZ_ENKA_SKILLTYPE_TO_GPY_SKILLTYPE[skill.type],
+                items=[],
             )
             for skill in agent.skills
         ]
@@ -432,10 +427,11 @@ class GenshinClient(ProxyGenshinClient):
             id=agent.id,
             name=agent.name,
             level=agent.level,
+            element=ZZZ_ENKA_ELEMENT_TO_ZZZELEMENTTYPE[agent.elements[0]],
             w_engine=w_engine,
             discs=discs,
             rank=agent.mindscape,
-            skills=skills
+            skills=skills,
         )
 
     async def get_hoyolab_gi_characters(self) -> list[models.HoyolabGICharacter]:

--- a/hoyo_buddy/hoyo/clients/gpy.py
+++ b/hoyo_buddy/hoyo/clients/gpy.py
@@ -26,7 +26,6 @@ from hoyo_buddy.constants import (
     POST_REPLIES,
     ZZZ_ENKA_AGENT_STAT_TYPE_TO_ZZZ_AGENT_PROPERTY,
     ZZZ_ENKA_ELEMENT_TO_ZZZELEMENTTYPE,
-    ZZZ_ENKA_PROFESSION_TO_GPY_ZZZSPECIALTY,
     ZZZ_ENKA_SKILLTYPE_TO_GPY_SKILLTYPE,
     ZZZ_ENKA_STAT_TO_GPY_ZZZ_PROPERTY,
     ZZZ_RARITY_NUM_TO_RARITY,
@@ -362,80 +361,62 @@ class GenshinClient(ProxyGenshinClient):
     @staticmethod
     def convert_zzz_character(agent: enka.zzz.Agent) -> models.ZZZEnkaCharacter:
         """Convert Agent from enka.zzz to ZZZEnkaCharacter that's used for drawing cards."""
-        w_engine: genshin.models.WEngine | None = None
+        w_engine: models.WEngine | None = None
         if agent.w_engine is not None:
-            w_engine = genshin.models.WEngine(
-                id=agent.w_engine.id,
-                level=agent.w_engine.level,
-                name=agent.w_engine.name,
+            w_engine = models.WEngine(
                 icon=agent.w_engine.icon,
-                star=agent.w_engine.phase,
-                rarity=ZZZ_RARITY_NUM_TO_RARITY[agent.w_engine.rarity_num],
+                level=agent.w_engine.level,
+                refinement=agent.w_engine.phase,
+                name=agent.w_engine.name,
                 properties=[
-                    genshin.models.ZZZProperty(
-                        property_name=agent.w_engine.sub_stat.name,
-                        property_id=ZZZ_ENKA_STAT_TO_GPY_ZZZ_PROPERTY[agent.w_engine.sub_stat.type],
-                        base=agent.w_engine.sub_stat.formatted_value,
+                    models.ZZZStat(
+                        name=agent.w_engine.sub_stat.name,
+                        type=ZZZ_ENKA_STAT_TO_GPY_ZZZ_PROPERTY[agent.w_engine.sub_stat.type],
+                        value=agent.w_engine.sub_stat.formatted_value,
                     )
                 ],
                 main_properties=[
-                    genshin.models.ZZZProperty(
-                        property_name=agent.w_engine.main_stat.name,
-                        property_id=ZZZ_ENKA_STAT_TO_GPY_ZZZ_PROPERTY[
-                            agent.w_engine.main_stat.type
-                        ],
-                        base=agent.w_engine.main_stat.formatted_value,
+                    models.ZZZStat(
+                        name=agent.w_engine.main_stat.name,
+                        type=ZZZ_ENKA_STAT_TO_GPY_ZZZ_PROPERTY[agent.w_engine.main_stat.type],
+                        value=agent.w_engine.main_stat.formatted_value,
                     )
                 ],
-                talent_title="",
-                talent_content="",
-                profession=ZZZ_ENKA_PROFESSION_TO_GPY_ZZZSPECIALTY[agent.w_engine.specialty],
             )
         props = [
-            genshin.models.ZZZAgentProperty(
-                property_name=stat.name,
-                property_id=ZZZ_ENKA_AGENT_STAT_TYPE_TO_ZZZ_AGENT_PROPERTY[stat_type],
-                base=stat.formatted_value,
-                add="",
-                final="",
+            models.ZZZStat(
+                name=stat.name,
+                type=ZZZ_ENKA_AGENT_STAT_TYPE_TO_ZZZ_AGENT_PROPERTY[stat_type],
+                value=stat.formatted_value,
             )
             for stat_type, stat in agent.stats.items()
         ]
         discs = [
-            genshin.models.ZZZDisc(
+            models.ZZZDiscDrive(
                 id=disc.id,
                 level=disc.level,
-                name=str(disc.uid),
-                icon="",
-                rarity=ZZZ_RARITY_NUM_TO_RARITY[disc.rarity_num],
                 main_properties=[
-                    genshin.models.ZZZProperty(
-                        property_name=disc.main_stat.name,
-                        property_id=ZZZ_ENKA_STAT_TO_GPY_ZZZ_PROPERTY[disc.main_stat.type],
-                        base=disc.main_stat.formatted_value,
+                    models.ZZZStat(
+                        name=disc.main_stat.name,
+                        type=ZZZ_ENKA_STAT_TO_GPY_ZZZ_PROPERTY[disc.main_stat.type],
+                        value=disc.main_stat.formatted_value,
                     )
                 ],
                 properties=[
-                    genshin.models.ZZZProperty(
-                        property_name=prop.name,
-                        property_id=ZZZ_ENKA_STAT_TO_GPY_ZZZ_PROPERTY[prop.type],
-                        base=prop.formatted_value,
+                    models.ZZZStat(
+                        name=prop.name,
+                        type=ZZZ_ENKA_STAT_TO_GPY_ZZZ_PROPERTY[prop.type],
+                        value=prop.formatted_value,
                     )
                     for prop in disc.sub_stats
                 ],
-                equip_suit=genshin.models.DiscSetEffect(
-                    suit_id=disc.set_id, name="", own=0, desc1="", desc2=""
-                ),
-                equipment_type=disc.slot,
+                rarity=ZZZ_RARITY_NUM_TO_RARITY[disc.rarity_num],
+                position=disc.slot,
             )
             for disc in agent.discs
         ]
         skills = [
-            genshin.models.AgentSkill(
-                level=skill.level,
-                skill_type=ZZZ_ENKA_SKILLTYPE_TO_GPY_SKILLTYPE[skill.type],
-                items=[],
-            )
+            models.ZZZSkill(level=skill.level, type=ZZZ_ENKA_SKILLTYPE_TO_GPY_SKILLTYPE[skill.type])
             for skill in agent.skills
         ]
         return models.ZZZEnkaCharacter(

--- a/hoyo_buddy/hoyo/clients/gpy.py
+++ b/hoyo_buddy/hoyo/clients/gpy.py
@@ -260,7 +260,6 @@ class GenshinClient(ProxyGenshinClient):
                 models.HoyolabGITalent(icon=talent.icon, level=talent.level, id=talent.id)
                 for talent in character.skills
             ],
-            # what about this thing here
             artifacts=artifacts,
             friendship_level=character.friendship,
             level=character.level,
@@ -404,10 +403,10 @@ class GenshinClient(ProxyGenshinClient):
                 ],
                 properties=[
                     genshin.models.ZZZProperty(
-                    property_name=property.name,
-                    property_id=ZZZ_ENKA_STAT_TO_GPY_ZZZ_PROPERTY[property.type],
-                    base=property.formatted_value
-                ) for property in disc.sub_stats
+                    property_name=prop.name,
+                    property_id=ZZZ_ENKA_STAT_TO_GPY_ZZZ_PROPERTY[prop.type],
+                    base=prop.formatted_value
+                ) for prop in disc.sub_stats
                 ],
                 set_effect=genshin.models.DiscSetEffect(
                         id=disc.set_id,

--- a/hoyo_buddy/hoyo/clients/gpy.py
+++ b/hoyo_buddy/hoyo/clients/gpy.py
@@ -429,6 +429,7 @@ class GenshinClient(ProxyGenshinClient):
             discs=discs,
             rank=agent.mindscape,
             skills=skills,
+            outfit_id=agent.skin_id
         )
 
     async def get_hoyolab_gi_characters(self) -> list[models.HoyolabGICharacter]:

--- a/hoyo_buddy/hoyo/clients/gpy.py
+++ b/hoyo_buddy/hoyo/clients/gpy.py
@@ -24,6 +24,7 @@ from hoyo_buddy.constants import (
     PLAYER_BOY_GACHA_ART,
     PLAYER_GIRL_GACHA_ART,
     POST_REPLIES,
+    ZZZ_ENKA_AGENT_STAT_TYPE_TO_ZZZ_AGENT_PROPERTY,
     ZZZ_ENKA_ELEMENT_TO_ZZZELEMENTTYPE,
     ZZZ_ENKA_PROFESSION_TO_GPY_ZZZSPECIALTY,
     ZZZ_ENKA_SKILLTYPE_TO_GPY_SKILLTYPE,
@@ -361,31 +362,45 @@ class GenshinClient(ProxyGenshinClient):
     @staticmethod
     def convert_zzz_character(agent: enka.zzz.Agent) -> models.ZZZEnkaCharacter:
         """Convert Agent from enka.zzz to ZZZEnkaCharacter that's used for drawing cards."""
-        w_engine = genshin.models.WEngine(
-            id=agent.w_engine.id,
-            level=agent.w_engine.level,
-            name=agent.w_engine.name,
-            icon=agent.w_engine.icon,
-            star=agent.w_engine.phase,
-            rarity=ZZZ_RARITY_NUM_TO_RARITY[agent.w_engine.rarity_num],
-            properties=[
-                genshin.models.ZZZProperty(
-                    property_name=agent.w_engine.sub_stat.name,
-                    property_id=ZZZ_ENKA_STAT_TO_GPY_ZZZ_PROPERTY[agent.w_engine.sub_stat.type],
-                    base=agent.w_engine.sub_stat.formatted_value,
-                )
-            ],
-            main_properties=[
-                genshin.models.ZZZProperty(
-                    property_name=agent.w_engine.main_stat.name,
-                    property_id=ZZZ_ENKA_STAT_TO_GPY_ZZZ_PROPERTY[agent.w_engine.main_stat.type],
-                    base=agent.w_engine.main_stat.formatted_value,
-                )
-            ],
-            talent_title="",
-            talent_content="",
-            profession=ZZZ_ENKA_PROFESSION_TO_GPY_ZZZSPECIALTY[agent.w_engine.specialty],
-        )
+        w_engine: genshin.models.WEngine | None = None
+        if agent.w_engine is not None:
+            w_engine = genshin.models.WEngine(
+                id=agent.w_engine.id,
+                level=agent.w_engine.level,
+                name=agent.w_engine.name,
+                icon=agent.w_engine.icon,
+                star=agent.w_engine.phase,
+                rarity=ZZZ_RARITY_NUM_TO_RARITY[agent.w_engine.rarity_num],
+                properties=[
+                    genshin.models.ZZZProperty(
+                        property_name=agent.w_engine.sub_stat.name,
+                        property_id=ZZZ_ENKA_STAT_TO_GPY_ZZZ_PROPERTY[agent.w_engine.sub_stat.type],
+                        base=agent.w_engine.sub_stat.formatted_value,
+                    )
+                ],
+                main_properties=[
+                    genshin.models.ZZZProperty(
+                        property_name=agent.w_engine.main_stat.name,
+                        property_id=ZZZ_ENKA_STAT_TO_GPY_ZZZ_PROPERTY[
+                            agent.w_engine.main_stat.type
+                        ],
+                        base=agent.w_engine.main_stat.formatted_value,
+                    )
+                ],
+                talent_title="",
+                talent_content="",
+                profession=ZZZ_ENKA_PROFESSION_TO_GPY_ZZZSPECIALTY[agent.w_engine.specialty],
+            )
+        props = [
+            genshin.models.ZZZAgentProperty(
+                property_name=stat.name,
+                property_id=ZZZ_ENKA_AGENT_STAT_TYPE_TO_ZZZ_AGENT_PROPERTY[stat_type],
+                base=stat.formatted_value,
+                add="",
+                final="",
+            )
+            for stat_type, stat in agent.stats.items()
+        ]
         discs = [
             genshin.models.ZZZDisc(
                 id=disc.id,
@@ -429,6 +444,7 @@ class GenshinClient(ProxyGenshinClient):
             level=agent.level,
             element=ZZZ_ENKA_ELEMENT_TO_ZZZELEMENTTYPE[agent.elements[0]],
             w_engine=w_engine,
+            properties=props,
             discs=discs,
             rank=agent.mindscape,
             skills=skills,

--- a/hoyo_buddy/hoyo/clients/gpy.py
+++ b/hoyo_buddy/hoyo/clients/gpy.py
@@ -24,6 +24,10 @@ from hoyo_buddy.constants import (
     PLAYER_BOY_GACHA_ART,
     PLAYER_GIRL_GACHA_ART,
     POST_REPLIES,
+    ZZZ_RARITY_NUM_TO_RARITY,
+    ZZZ_ENKA_STAT_TO_GPY_ZZZ_PROPERTY,
+    ZZZ_ENKA_PROFESSION_TO_GPY_ZZZSPECIALTY,
+    ZZZ_ENKA_SKILLTYPE_TO_GPY_SKILLTYPE,
     contains_traveler_id,
     convert_fight_prop,
 )
@@ -256,6 +260,7 @@ class GenshinClient(ProxyGenshinClient):
                 models.HoyolabGITalent(icon=talent.icon, level=talent.level, id=talent.id)
                 for talent in character.skills
             ],
+            # what about this thing here
             artifacts=artifacts,
             friendship_level=character.friendship,
             level=character.level,
@@ -351,6 +356,87 @@ class GenshinClient(ProxyGenshinClient):
                 hakushin.Game.HSR,
             ),
             path=GPY_PATH_TO_EKNA_PATH[c.path],
+        )
+    
+    @staticmethod
+    def convert_zzz_character(
+        agent: enka.zzz.Agent,
+    ) -> models.ZZZEnkaCharacter:
+        """Convert Agent from enka.zzz to ZZZEnkaCharacter that's used for drawing cards."""
+        w_engine = genshin.models.WEngine(
+            id=agent.w_engine.id,
+            level=agent.w_engine.level,
+            name=agent.w_engine.name,
+            icon=agent.w_engine.icon,
+            refinement=agent.w_engine.phase,
+            rarity=ZZZ_RARITY_NUM_TO_RARITY[agent.w_engine.rarity_num],
+            properties=[
+                genshin.models.ZZZProperty(
+                    property_name=agent.w_engine.sub_stat.name,
+                    property_id=ZZZ_ENKA_STAT_TO_GPY_ZZZ_PROPERTY[agent.w_engine.sub_stat.type],
+                    base=agent.w_engine.sub_stat.formatted_value
+                )
+            ],
+            main_properties=[
+                genshin.models.ZZZProperty(
+                    property_name=agent.w_engine.main_stat.name,
+                    property_id=ZZZ_ENKA_STAT_TO_GPY_ZZZ_PROPERTY[agent.w_engine.main_stat.type],
+                    base=agent.w_engine.main_stat.formatted_value
+                )
+            ],
+            effect_title="",
+            effect_description="",
+            profession=ZZZ_ENKA_PROFESSION_TO_GPY_ZZZSPECIALTY[agent.w_engine.specialty]
+        )
+        discs = [
+            genshin.models.ZZZDisc(
+                id=disc.id,
+                level=disc.level,
+                name=disc.uid,
+                icon="",
+                rarity=ZZZ_RARITY_NUM_TO_RARITY[disc.rarity_num],
+                main_properties=[
+                    genshin.models.ZZZProperty(
+                    property_name=disc.main_stat.name,
+                    property_id=ZZZ_ENKA_STAT_TO_GPY_ZZZ_PROPERTY[disc.main_stat.type],
+                    base=disc.main_stat.formatted_value
+                )
+                ],
+                properties=[
+                    genshin.models.ZZZProperty(
+                    property_name=property.name,
+                    property_id=ZZZ_ENKA_STAT_TO_GPY_ZZZ_PROPERTY[property.type],
+                    base=property.formatted_value
+                ) for property in disc.sub_stats
+                ],
+                set_effect=genshin.models.DiscSetEffect(
+                        id=disc.set_id,
+                        name="",
+                        owned_num=0,
+                        two_piece_description="",
+                        four_piece_description=""
+                    ),
+                position=disc.slot,
+
+            )
+            for disc in agent.discs
+        ]
+        skills = [
+            genshin.models.AgentSkill(
+                level=skill.level,
+                type=ZZZ_ENKA_SKILLTYPE_TO_GPY_SKILLTYPE[skill.type],
+                items=[]
+            )
+            for skill in agent.skills
+        ]
+        return models.ZZZEnkaCharacter(
+            id=agent.id,
+            name=agent.name,
+            level=agent.level,
+            w_engine=w_engine,
+            discs=discs,
+            rank=agent.mindscape,
+            skills=skills
         )
 
     async def get_hoyolab_gi_characters(self) -> list[models.HoyolabGICharacter]:

--- a/hoyo_buddy/models.py
+++ b/hoyo_buddy/models.py
@@ -249,6 +249,24 @@ class AgentNameData(BaseModel):
     full_name: str
     short_name: str
 
+@dataclass(kw_only=True)
+class ZZZEnkaCharacter(BaseModel):
+    id: int
+    name: str
+    level: int
+    w_engine: genshin.models.WEngine
+    discs: list[genshin.models.ZZZDisc]
+    rank: int
+    skills: list[genshin.models.AgentSkill]
+
+    @property
+    def base_icon_url(self) -> str:
+        return "https://act-webstatic.hoyoverse.com/game_record/zzzv2"
+    
+    @property
+    def banner_icon(self) -> str:
+        """Example: https://act-webstatic.hoyoverse.com/game_record/zzz/role_vertical_painting/role_vertical_painting_1131.png"""
+        return f"{self.base_icon_url}/role_vertical_painting/role_vertical_painting_{self.id}.png"
 
 class ZZZDrawData(BaseModel):
     name_data: dict[int, AgentNameData]

--- a/hoyo_buddy/models.py
+++ b/hoyo_buddy/models.py
@@ -261,7 +261,7 @@ class ZZZEnkaCharacter:
     properties: list[ZZZStat]
     discs: list[ZZZDiscDrive]
     rank: int
-    skills: list[genshin.models.AgentSkill]
+    skills: list[ZZZSkill]
     outfit_id: int | None
 
     @property

--- a/hoyo_buddy/models.py
+++ b/hoyo_buddy/models.py
@@ -261,7 +261,8 @@ class ZZZEnkaCharacter:
     properties: list[ZZZStat]
     discs: list[ZZZDiscDrive]
     rank: int
-    skills: list[ZZZSkill]
+    skills: list[genshin.models.AgentSkill]
+    outfit_id: int | None
 
     @property
     def base_icon_url(self) -> str:

--- a/hoyo_buddy/models.py
+++ b/hoyo_buddy/models.py
@@ -256,7 +256,8 @@ class ZZZEnkaCharacter:
     name: str
     level: int
     element: genshin.models.ZZZElementType
-    w_engine: genshin.models.WEngine
+    w_engine: genshin.models.WEngine | None = None
+    properties: list[genshin.models.ZZZAgentProperty]
     discs: list[genshin.models.ZZZDisc]
     rank: int
     skills: list[genshin.models.AgentSkill]

--- a/hoyo_buddy/models.py
+++ b/hoyo_buddy/models.py
@@ -243,6 +243,7 @@ class UnownedZZZCharacter(BaseModel):
     faction_name: str
     rank: int = 0
     banner_icon: str
+    w_engine: WEngine | None = None
 
 
 class AgentNameData(BaseModel):
@@ -256,11 +257,11 @@ class ZZZEnkaCharacter:
     name: str
     level: int
     element: genshin.models.ZZZElementType
-    w_engine: genshin.models.WEngine | None = None
-    properties: list[genshin.models.ZZZAgentProperty]
-    discs: list[genshin.models.ZZZDisc]
+    w_engine: WEngine | None = None
+    properties: list[ZZZStat]
+    discs: list[ZZZDiscDrive]
     rank: int
-    skills: list[genshin.models.AgentSkill]
+    skills: list[ZZZSkill]
 
     @property
     def base_icon_url(self) -> str:
@@ -268,8 +269,41 @@ class ZZZEnkaCharacter:
 
     @property
     def banner_icon(self) -> str:
-        """Example: https://act-webstatic.hoyoverse.com/game_record/zzz/role_vertical_painting/role_vertical_painting_1131.png"""
+        """Example: https://act-webstatic.hoyoverse.com/game_record/zzzv2/role_vertical_painting/role_vertical_painting_1131.png"""
         return f"{self.base_icon_url}/role_vertical_painting/role_vertical_painting_{self.id}.png"
+
+
+@dataclass(kw_only=True)
+class WEngine:
+    icon: str
+    level: int
+    refinement: int
+    name: str
+    main_properties: list[ZZZStat]
+    properties: list[ZZZStat]
+
+
+@dataclass(kw_only=True)
+class ZZZDiscDrive:
+    id: int
+    level: int
+    main_properties: list[ZZZStat]
+    properties: list[ZZZStat]
+    rarity: Literal["B", "A", "S"]
+    position: int
+
+
+@dataclass(kw_only=True)
+class ZZZStat:
+    name: str
+    type: genshin.models.ZZZPropertyType
+    value: str
+
+
+@dataclass(kw_only=True)
+class ZZZSkill:
+    level: int
+    type: genshin.models.ZZZSkillType
 
 
 class ZZZDrawData(BaseModel):

--- a/hoyo_buddy/models.py
+++ b/hoyo_buddy/models.py
@@ -250,7 +250,7 @@ class AgentNameData(BaseModel):
     short_name: str
 
 @dataclass(kw_only=True)
-class ZZZEnkaCharacter(BaseModel):
+class ZZZEnkaCharacter:
     id: int
     name: str
     level: int

--- a/hoyo_buddy/models.py
+++ b/hoyo_buddy/models.py
@@ -249,11 +249,13 @@ class AgentNameData(BaseModel):
     full_name: str
     short_name: str
 
+
 @dataclass(kw_only=True)
 class ZZZEnkaCharacter:
     id: int
     name: str
     level: int
+    element: genshin.models.ZZZElementType
     w_engine: genshin.models.WEngine
     discs: list[genshin.models.ZZZDisc]
     rank: int
@@ -262,11 +264,12 @@ class ZZZEnkaCharacter:
     @property
     def base_icon_url(self) -> str:
         return "https://act-webstatic.hoyoverse.com/game_record/zzzv2"
-    
+
     @property
     def banner_icon(self) -> str:
         """Example: https://act-webstatic.hoyoverse.com/game_record/zzz/role_vertical_painting/role_vertical_painting_1131.png"""
         return f"{self.base_icon_url}/role_vertical_painting/role_vertical_painting_{self.id}.png"
+
 
 class ZZZDrawData(BaseModel):
     name_data: dict[int, AgentNameData]

--- a/hoyo_buddy/types.py
+++ b/hoyo_buddy/types.py
@@ -53,6 +53,7 @@ Character: TypeAlias = (
     | enka.hsr.Character
     | genshin.models.ZZZPartialAgent
     | models.HoyolabGICharacter
+    | enka.zzz.Agent
 )
 HoyolabCharacter: TypeAlias = (
     models.HoyolabHSRCharacter | models.HoyolabGICharacter | genshin.models.ZZZPartialAgent

--- a/hoyo_buddy/types.py
+++ b/hoyo_buddy/types.py
@@ -53,7 +53,7 @@ Character: TypeAlias = (
     | enka.hsr.Character
     | genshin.models.ZZZPartialAgent
     | models.HoyolabGICharacter
-    | enka.zzz.Agent
+    | models.ZZZEnkaCharacter
 )
 HoyolabCharacter: TypeAlias = (
     models.HoyolabHSRCharacter | models.HoyolabGICharacter | genshin.models.ZZZPartialAgent

--- a/hoyo_buddy/ui/hoyo/profile/view.py
+++ b/hoyo_buddy/ui/hoyo/profile/view.py
@@ -528,7 +528,7 @@ class ProfileView(View):
         assert isinstance(character, ZZZPartialAgent | ZZZEnkaCharacter)
 
         # NOTE: This line is for testing new characters' templates
-        character_id = character.id
+        # character_id = character.id
         agent: ZZZFullAgent | ZZZEnkaCharacter | None = None
 
         if isinstance(character, ZZZEnkaCharacter):

--- a/hoyo_buddy/ui/hoyo/profile/view.py
+++ b/hoyo_buddy/ui/hoyo/profile/view.py
@@ -4,7 +4,6 @@ from io import BytesIO
 from typing import TYPE_CHECKING, Any, Literal
 
 import aiohttp
-from numpy import isin
 import akasha
 import enka
 from discord import File
@@ -536,7 +535,7 @@ class ProfileView(View):
             agent = character
         else:
             if self._account is None:
-                raise ValueError("Cannot fetch full agent details without a logged-in account.")
+                raise ValueError
 
             client = self._account.client
             client.set_lang(self.locale)
@@ -658,13 +657,14 @@ class ProfileView(View):
         if self.game is Game.ZZZ:
             agents: list[ZZZFullAgent | ZZZEnkaCharacter] = []
             for char_id in self.character_ids:
-                if isinstance(self.characters[char_id], ZZZPartialAgent):
+                character = self.characters[char_id]
+                if isinstance(character, ZZZPartialAgent):
                     assert self._account is not None
                     client = self._account.client
                     client.set_lang(self.locale)
                     agents.append(await client.get_zzz_agent_info(int(char_id)))
-                else:
-                    agents.append(self.characters[char_id])
+                elif isinstance(character, ZZZEnkaCharacter):
+                    agents.append(character)
 
             agent_card_settings = {
                 int(char_id): await get_card_settings(i.user.id, char_id, game=self.game)

--- a/hoyo_buddy/ui/hoyo/profile/view.py
+++ b/hoyo_buddy/ui/hoyo/profile/view.py
@@ -104,7 +104,7 @@ class ProfileView(View):
 
         self.starrail_data = starrail_data
         self.genshin_data = genshin_data
-        self.zzz_data = zzz_data
+        self.zzz_data = zzz_data or []
         self.zzz_user = zzz_user
         self.zzz_enka_data = zzz_enka_data
 
@@ -183,15 +183,26 @@ class ProfileView(View):
                 enka_chara_ids.append(str(chara.id))
                 self.characters[str(chara.id)] = chara
 
+    def _set_zzz_characters_with_enka(self) -> None:
+        data = self.zzz_enka_data
+        enka_chara_ids: list[str] = []
+        if data is not None:
+            for chara in data.agents:
+                enka_chara_ids.append(str(chara.id))
+                self.characters[str(chara.id)] = chara
+
+        for chara in self.zzz_data:
+            if str(chara.id) not in enka_chara_ids:
+                enka_chara_ids.append(str(chara.id))
+                self.characters[str(chara.id)] = chara
+
     def _set_characters(self) -> None:
         if self.game is Game.STARRAIL:
             self._set_characters_with_enka(Game.STARRAIL)
         elif self.game is Game.GENSHIN:
             self._set_characters_with_enka(Game.GENSHIN)
         elif self.game is Game.ZZZ:
-            assert self.zzz_data is not None
-            for chara in self.zzz_data:
-                self.characters[str(chara.id)] = chara
+            self._set_zzz_characters_with_enka()
 
         for character_id in self._param_character_ids:
             if (

--- a/hoyo_buddy/ui/hoyo/profile/view.py
+++ b/hoyo_buddy/ui/hoyo/profile/view.py
@@ -535,7 +535,8 @@ class ProfileView(View):
             agent = character
         else:
             if self._account is None:
-                raise ValueError
+                msg = "Cannot fetch full agent details without a logged-in account."
+                raise ValueError(msg)
 
             client = self._account.client
             client.set_lang(self.locale)

--- a/hoyo_buddy/ui/hoyo/profile/view.py
+++ b/hoyo_buddy/ui/hoyo/profile/view.py
@@ -87,6 +87,7 @@ class ProfileView(View):
         starrail_data: enka.hsr.ShowcaseResponse | None = None,
         genshin_data: enka.gi.ShowcaseResponse | None = None,
         zzz_data: Sequence[ZZZPartialAgent] | None = None,
+        zzz_enka_data: enka.zzz.ShowcaseResponse | None = None,
         zzz_user: RecordCard | None = None,
         account: HoyoAccount | None,
         builds: Builds | None = None,
@@ -105,6 +106,7 @@ class ProfileView(View):
         self.genshin_data = genshin_data
         self.zzz_data = zzz_data
         self.zzz_user = zzz_user
+        self.zzz_enka_data = zzz_enka_data
 
         self.uid = uid
         self.game = game

--- a/run.py
+++ b/run.py
@@ -50,7 +50,7 @@ async def main() -> None:
 if __name__ == "__main__":
     entry_point("logs/hoyo_buddy.log")
     try:
-        import uvloop  # pyright: ignore[reportMissingImports]
+        import uvloop
     except ImportError:
         asyncio.run(main())
     else:


### PR DESCRIPTION
The changes include adding a function to convert enka.py's Agent into a new model called ZZZEnkaCharacter for creating cards, so that users of Hoyo Buddy just need a UID to see others' agents. These code changes also involve changing some code within UI components to accept UIDs from users to then fetch from enka.py's client. From the previous pull request made, most of the bugs have been fixed. 