### PR TITLE
[/about] Change Discord User Link to URI Protocol instead of URL web link

### DIFF
--- a/hoyo_buddy/utils/misc.py
+++ b/hoyo_buddy/utils/misc.py
@@ -59,8 +59,8 @@ __all__ = (
     "format_timedelta",
     "get_discord_protocol_url",
     "get_discord_url",
-    "get_discord_user_link",
     "get_discord_user_md_link",
+    "get_discord_user_protocol_url",
     "get_floor_difficulty",
     "get_mimo_task_str",
     "get_mimo_task_url",
@@ -202,14 +202,14 @@ def blur_uid(uid: int, *, arterisk: str = "x") -> str:
     return uid_[: middle_index - 2] + arterisk * 5 + uid_[middle_index + 3 :]
 
 
-def get_discord_user_link(user_id: int) -> str:
+def get_discord_user_protocol_url(user_id: int) -> str:
     """Get the link to a Discord user's profile."""
     return f"discord://-/users/{user_id}"
 
 
 def get_discord_user_md_link(user: discord.User | discord.Member) -> str:
     """Get the Markdown-formatted link to a Discord user's profile."""
-    return f"[@{user}](<{get_discord_user_link(user.id)}>)"
+    return f"[@{user}](<{get_discord_user_protocol_url(user.id)}>)"
 
 
 def convert_to_title_case(s: str) -> str:


### PR DESCRIPTION
As said in Issue [HB-125](https://linear.app/seria-studio/issue/HB-125/usernames-in-about-should-use-uri-protocols-instead-of-url), this PR change /about embed to use Discord URI instead or using URL web link, making the user experience more intiutive by directly opening the Profile Page in the Discord app instead of opening a new browser for whatever reason on certain devices