### PR TITLE
fix(security): 2 improvements across 1 files

### DIFF
--- a/hoyo_buddy/api/routers/geetest.py
+++ b/hoyo_buddy/api/routers/geetest.py
@@ -13,7 +13,9 @@ router = APIRouter()
 
 
 @router.post("/notify")
-async def handle_geetest_notify(body: GeetestCommandRequest, auth=Depends(require_auth)) -> dict[str, str]:
+async def handle_geetest_notify(
+    body: GeetestCommandRequest, auth=Depends(require_auth)
+) -> dict[str, str]:
     """Perform the geetest-gated action (daily check-in or MMT verification) for an account."""
     try:
         gt_type = GeetestType(body.gt_type)

--- a/hoyo_buddy/api/routers/geetest.py
+++ b/hoyo_buddy/api/routers/geetest.py
@@ -1,27 +1,36 @@
 from __future__ import annotations
 
 import genshin
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Depends, HTTPException
 
 from hoyo_buddy.db.models import HoyoAccount
 from hoyo_buddy.enums import GeetestType
 
+from ..auth import require_auth
 from ..schemas import GeetestCommandRequest
 
 router = APIRouter()
 
 
 @router.post("/notify")
-async def handle_geetest_notify(body: GeetestCommandRequest) -> dict[str, str]:
+async def handle_geetest_notify(body: GeetestCommandRequest, auth=Depends(require_auth)) -> dict[str, str]:
     """Perform the geetest-gated action (daily check-in or MMT verification) for an account."""
     try:
         gt_type = GeetestType(body.gt_type)
     except ValueError as exc:
         raise HTTPException(status_code=422, detail=f"Invalid gt_type: {body.gt_type}") from exc
 
-    account = await HoyoAccount.get_or_none(id=body.account_id)
+    user_id = getattr(auth, "id", None)
+    if user_id is None:
+        user_id = getattr(auth, "user_id", None)
+    if user_id is None and isinstance(auth, dict):
+        user_id = auth.get("id") or auth.get("user_id")
+    if user_id is None:
+        raise HTTPException(status_code=403, detail="Forbidden")
+
+    account = await HoyoAccount.get_or_none(id=body.account_id, user_id=user_id)
     if account is None:
-        raise HTTPException(status_code=404, detail="Account not found")
+        raise HTTPException(status_code=403, detail="Forbidden")
 
     client = account.client
 


### PR DESCRIPTION
## Summary

fix(security): 2 improvements across 1 files

## Problem

**Severity**: `Critical` | **File**: `hoyo_buddy/api/routers/geetest.py:L15`

The `/api/geetest/notify` route performs sensitive actions (`claim_daily_reward` / `verify_mmt`) on an account selected by `body.account_id`, but it does not require authentication or verify ownership of the target account. An attacker can submit arbitrary account IDs and trigger actions on other users' linked accounts.

## Solution

Require authenticated sessions on this endpoint (e.g., `Depends(require_auth)`), fetch the account by both `id` and authenticated `user_id`, and reject mismatches with 403. Consider adding anti-replay protection and per-account rate limiting.

## Changes

- `hoyo_buddy/api/routers/geetest.py` (modified)