### PR TITLE
feat(profile): add Enka style cards for HSR and ZZZ

### DIFF
--- a/hoyo_buddy/api/deps.py
+++ b/hoyo_buddy/api/deps.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Annotated, Any
 
 import genshin
-from fastapi import Depends, HTTPException, Request, Response  # noqa: TC002
+from fastapi import Depends, HTTPException, Request, Response
 from loguru import logger
 
 DEVICE_ID_COOKIE = "hb_device_id"

--- a/hoyo_buddy/commands/profile.py
+++ b/hoyo_buddy/commands/profile.py
@@ -226,4 +226,5 @@ class ProfileCommand:
             author=self._user,
             locale=self._locale,
             builds=builds,
+            owner=enka_data.owner if enka_data is not None else None,
         )

--- a/hoyo_buddy/constants.py
+++ b/hoyo_buddy/constants.py
@@ -301,6 +301,27 @@ LOCALE_TO_GI_CARD_API_LANG: dict[Locale, str] = {
     Locale.turkish: "tr",
 }
 
+LOCALE_TO_ENKA_CARDS_LANG: dict[Locale, str] = {
+    Locale.taiwan_chinese: "zh-tw",
+    Locale.chinese: "zh-cn",
+    Locale.german: "de",
+    Locale.american_english: "en",
+    Locale.spain_spanish: "es",
+    Locale.french: "fr",
+    Locale.indonesian: "id",
+    Locale.italian: "it",
+    Locale.japanese: "ja",
+    Locale.korean: "ko",
+    Locale.brazil_portuguese: "pt",
+    Locale.russian: "ru",
+    Locale.thai: "th",
+    Locale.turkish: "tr",
+    Locale.vietnamese: "vi",
+    Locale.ukrainian: "uk",
+    Locale.dutch: "nl",
+    Locale.arabic: "ar",
+}
+
 HSR_ELEMENT_DMG_PROPS = {
     12,  # Physical
     22,  # Quantum

--- a/hoyo_buddy/ui/hoyo/challenge.py
+++ b/hoyo_buddy/ui/hoyo/challenge.py
@@ -49,7 +49,7 @@ if TYPE_CHECKING:
 
     from hoyo_buddy.db import HoyoAccount
     from hoyo_buddy.enums import Locale
-    from hoyo_buddy.types import Buff, Challenge, ChallengeWithLang, HardChallengeMode, Interaction
+    from hoyo_buddy.types import Buff, ChallengeWithLang, HardChallengeMode, Interaction
 
 ShowUIDChallenge: TypeAlias = (
     ShiyuDefense

--- a/hoyo_buddy/ui/hoyo/characters.py
+++ b/hoyo_buddy/ui/hoyo/characters.py
@@ -71,7 +71,6 @@ if TYPE_CHECKING:
     from discord import File, Member, User
 
     from hoyo_buddy.db import HoyoAccount
-    from hoyo_buddy.enums import Locale
     from hoyo_buddy.models import DrawInput
     from hoyo_buddy.types import Interaction
 

--- a/hoyo_buddy/ui/hoyo/events.py
+++ b/hoyo_buddy/ui/hoyo/events.py
@@ -22,7 +22,6 @@ if TYPE_CHECKING:
     import genshin
 
     from hoyo_buddy.db import HoyoAccount
-    from hoyo_buddy.enums import Locale
     from hoyo_buddy.types import Interaction, User
 
 

--- a/hoyo_buddy/ui/hoyo/genshin/search/tcg.py
+++ b/hoyo_buddy/ui/hoyo/genshin/search/tcg.py
@@ -4,7 +4,6 @@ from typing import TYPE_CHECKING
 
 from discord import ButtonStyle
 
-from hoyo_buddy.enums import Locale
 from hoyo_buddy.hoyo.clients.ambr import AmbrAPIClient
 from hoyo_buddy.l10n import LocaleStr
 from hoyo_buddy.ui import Button, Select, SelectOption, View

--- a/hoyo_buddy/ui/hoyo/genshin/search/weapon.py
+++ b/hoyo_buddy/ui/hoyo/genshin/search/weapon.py
@@ -4,7 +4,6 @@ from typing import TYPE_CHECKING, Any
 
 from discord import ButtonStyle
 
-from hoyo_buddy.enums import Locale
 from hoyo_buddy.exceptions import InvalidQueryError
 from hoyo_buddy.hoyo.clients.ambr import AmbrAPIClient
 from hoyo_buddy.l10n import LocaleStr

--- a/hoyo_buddy/ui/hoyo/hsr/search/character.py
+++ b/hoyo_buddy/ui/hoyo/hsr/search/character.py
@@ -5,7 +5,6 @@ from typing import TYPE_CHECKING, Any
 import yatta
 from discord import ButtonStyle
 
-from hoyo_buddy.enums import Locale
 from hoyo_buddy.hoyo.clients.yatta import YattaAPIClient
 from hoyo_buddy.l10n import LocaleStr
 from hoyo_buddy.ui import (

--- a/hoyo_buddy/ui/hoyo/hsr/search/light_cone.py
+++ b/hoyo_buddy/ui/hoyo/hsr/search/light_cone.py
@@ -5,7 +5,6 @@ from typing import TYPE_CHECKING, Any
 from discord import ButtonStyle
 
 from hoyo_buddy.embeds import DefaultEmbed
-from hoyo_buddy.enums import Locale
 from hoyo_buddy.exceptions import InvalidQueryError
 from hoyo_buddy.hoyo.clients.yatta import YattaAPIClient
 from hoyo_buddy.l10n import LocaleStr

--- a/hoyo_buddy/ui/hoyo/profile/image_settings.py
+++ b/hoyo_buddy/ui/hoyo/profile/image_settings.py
@@ -48,7 +48,6 @@ if TYPE_CHECKING:
     from discord import Member, User
 
     from hoyo_buddy.db import CardSettings, Settings
-    from hoyo_buddy.enums import Locale
     from hoyo_buddy.types import Character, Interaction
 
 

--- a/hoyo_buddy/ui/hoyo/profile/templates.py
+++ b/hoyo_buddy/ui/hoyo/profile/templates.py
@@ -95,10 +95,10 @@ TEMPLATE_PREVIEWS = {
     (Game.STARRAIL, "src1"): "https://iili.io/24hL2ig.png",
     (Game.STARRAIL, "src2"): "https://iili.io/24hLR0G.png",
     (Game.STARRAIL, "src3"): "https://iili.io/24hLw5Q.png",
-    (Game.STARRAIL, "enka1"): "https://img.seria.moe/REPLACE_HSR_ENKA_PREVIEW.png",
+    (Game.STARRAIL, "enka1"): "https://img.seria.moe/xrmRTweZsHNYXIIR.png",
     (Game.ZZZ, "hb1"): "https://img.seria.moe/xagKUlBObeSlQFuR.png",
     (Game.ZZZ, "hb2"): "https://img.seria.moe/aLcDReesAnNiAUzU.png",
     (Game.ZZZ, "hb3"): "https://img.seria.moe/chpFFHnUVEQTwqPC.png",
     (Game.ZZZ, "hb4"): "https://img.seria.moe/ODajRXtZUlCmTCks.png",
-    (Game.ZZZ, "enka1"): "https://img.seria.moe/REPLACE_ZZZ_ENKA_PREVIEW.png",
+    (Game.ZZZ, "enka1"): "https://img.seria.moe/drkKMmVfuasAlufI.png",
 }

--- a/hoyo_buddy/ui/hoyo/profile/templates.py
+++ b/hoyo_buddy/ui/hoyo/profile/templates.py
@@ -5,8 +5,8 @@ from hoyo_buddy.enums import Game
 
 TEMPLATES: dict[Game, tuple[str, ...]] = {
     Game.GENSHIN: ("hb1", "hb2", "hattvr1", "encard1", "enkacard1", "enkacard2"),
-    Game.STARRAIL: ("hb1", "hb2", "src1", "src2", "src3"),
-    Game.ZZZ: ("hb1", "hb2", "hb3", "hb4"),
+    Game.STARRAIL: ("hb1", "hb2", "src1", "src2", "src3", "enka1"),
+    Game.ZZZ: ("hb1", "hb2", "hb3", "hb4", "enka1"),
 }
 TEMPLATE_AUTHORS: dict[str, tuple[str, str]] = {
     "hb": ("@ayasaku_", "@seriaati"),
@@ -14,6 +14,7 @@ TEMPLATE_AUTHORS: dict[str, tuple[str, str]] = {
     "hattvr": ("@algoinde", "@hattvr"),
     "encard": ("@korzzex", "@korzzex"),
     "enkacard": ("@korzzex", "@korzzex"),
+    "enka": ("enka.network", "@LumiFae"),
 }
 TEMPLATE_NAMES = {
     "hb": "profile.card_template_select.hb.label",
@@ -21,6 +22,7 @@ TEMPLATE_NAMES = {
     "hattvr": "profile.card_template_select.enka_classic.label",
     "encard": "profile.card_template_select.encard.label",
     "enkacard": "profile.card_template_select.enkacard.label",
+    "enka": "profile.card_template_select.enka.label",
 }
 
 DISABLE_COLOR = {
@@ -35,10 +37,12 @@ DISABLE_COLOR = {
     (Game.STARRAIL, "src1"): False,
     (Game.STARRAIL, "src2"): False,
     (Game.STARRAIL, "src3"): False,
+    (Game.STARRAIL, "enka1"): True,
     (Game.ZZZ, "hb1"): False,
     (Game.ZZZ, "hb2"): False,
     (Game.ZZZ, "hb3"): False,
     (Game.ZZZ, "hb4"): False,
+    (Game.ZZZ, "enka1"): True,
 }
 DISABLE_DARK_MODE = {
     (Game.GENSHIN, "hb1"): False,
@@ -52,10 +56,12 @@ DISABLE_DARK_MODE = {
     (Game.STARRAIL, "src1"): True,
     (Game.STARRAIL, "src2"): True,
     (Game.STARRAIL, "src3"): True,
+    (Game.STARRAIL, "enka1"): True,
     (Game.ZZZ, "hb1"): True,
     (Game.ZZZ, "hb2"): True,
     (Game.ZZZ, "hb3"): True,
     (Game.ZZZ, "hb4"): True,
+    (Game.ZZZ, "enka1"): True,
 }
 DISABLE_IMAGE = {
     (Game.GENSHIN, "hb1"): False,
@@ -69,10 +75,12 @@ DISABLE_IMAGE = {
     (Game.STARRAIL, "src1"): False,
     (Game.STARRAIL, "src2"): False,
     (Game.STARRAIL, "src3"): False,
+    (Game.STARRAIL, "enka1"): True,
     (Game.ZZZ, "hb1"): True,
     (Game.ZZZ, "hb2"): True,
     (Game.ZZZ, "hb3"): False,
     (Game.ZZZ, "hb4"): False,
+    (Game.ZZZ, "enka1"): True,
 }
 
 TEMPLATE_PREVIEWS = {
@@ -87,8 +95,10 @@ TEMPLATE_PREVIEWS = {
     (Game.STARRAIL, "src1"): "https://iili.io/24hL2ig.png",
     (Game.STARRAIL, "src2"): "https://iili.io/24hLR0G.png",
     (Game.STARRAIL, "src3"): "https://iili.io/24hLw5Q.png",
+    (Game.STARRAIL, "enka1"): "https://img.seria.moe/REPLACE_HSR_ENKA_PREVIEW.png",
     (Game.ZZZ, "hb1"): "https://img.seria.moe/xagKUlBObeSlQFuR.png",
     (Game.ZZZ, "hb2"): "https://img.seria.moe/aLcDReesAnNiAUzU.png",
     (Game.ZZZ, "hb3"): "https://img.seria.moe/chpFFHnUVEQTwqPC.png",
     (Game.ZZZ, "hb4"): "https://img.seria.moe/ODajRXtZUlCmTCks.png",
+    (Game.ZZZ, "enka1"): "https://img.seria.moe/REPLACE_ZZZ_ENKA_PREVIEW.png",
 }

--- a/hoyo_buddy/ui/hoyo/profile/view.py
+++ b/hoyo_buddy/ui/hoyo/profile/view.py
@@ -68,7 +68,7 @@ if TYPE_CHECKING:
     from genshin.models import PartialGenshinUserStats, RecordCard, StarRailUserStats, ZZZFullAgent
 
     from hoyo_buddy.db import CardSettings, HoyoAccount
-    from hoyo_buddy.types import Builds, Character, Interaction
+    from hoyo_buddy.types import Character, Interaction
     from hoyo_buddy.ui import Button, Select
 
 

--- a/hoyo_buddy/ui/hoyo/profile/view.py
+++ b/hoyo_buddy/ui/hoyo/profile/view.py
@@ -67,7 +67,7 @@ if TYPE_CHECKING:
     from genshin.models import PartialGenshinUserStats, RecordCard, StarRailUserStats, ZZZFullAgent
 
     from hoyo_buddy.db import CardSettings, HoyoAccount
-    from hoyo_buddy.types import Builds, Character, Interaction
+    from hoyo_buddy.types import Character, Interaction
     from hoyo_buddy.ui import Button, Select
 
 

--- a/hoyo_buddy/ui/hoyo/profile/view.py
+++ b/hoyo_buddy/ui/hoyo/profile/view.py
@@ -14,6 +14,7 @@ from loguru import logger
 
 from hoyo_buddy.config import CONFIG
 from hoyo_buddy.constants import (
+    LOCALE_TO_ENKA_CARDS_LANG,
     LOCALE_TO_GI_CARD_API_LANG,
     LOCALE_TO_HSR_CARD_API_LANG,
     ZZZ_AVATAR_BATTLE_TEMP_JSON,
@@ -77,6 +78,8 @@ CARD_API_ENDPOINTS = {
     "enkacard": "http://localhost:7652/enka-card",
     "src": "http://localhost:7652/star-rail-card",
 }
+
+ENKA_CARDS_URL = "https://cards.enka.network"
 
 TOP_PERCENT_RANK_DECIMALS = 4
 
@@ -399,6 +402,32 @@ class ProfileView(View, PlayerEmbedMixin):
 
         return await self._request_draw_card_api(template, payload=payload, session=session)
 
+    async def _draw_enka_cards_card(
+        self, session: aiohttp.ClientSession, character: Character, card_settings: CardSettings
+    ) -> BytesIO:
+        """Draw HSR/ZZZ character card using the enka.cards service (enka.network style)."""
+        params = {
+            "lang": LOCALE_TO_ENKA_CARDS_LANG.get(await self.get_character_locale(character), "en"),
+            "substats": str(card_settings.show_substat_rolls).lower(),
+        }
+
+        if (
+            all((self._owner_username, self._owner_hash, self._build_id))
+            and self._build_id != "current"
+        ):
+            # Saved build on enka.network (game-agnostic /u/ route)
+            url = (
+                f"{ENKA_CARDS_URL}/u/{self._owner_username}/{self._owner_hash}"
+                f"/{character.id}/{self._build_id}/image"
+            )
+        else:
+            game_path = "hsr" if self.game is Game.STARRAIL else "zzz"
+            url = f"{ENKA_CARDS_URL}/{game_path}/{self.uid}/{character.id}/image"
+
+        async with session.get(url, params=params) as resp:
+            resp.raise_for_status()
+            return BytesIO(await resp.read())
+
     async def _draw_hb_hsr_character_card(
         self, character: Character, card_settings: CardSettings, draw_input: DrawInput
     ) -> BytesIO:
@@ -546,7 +575,11 @@ class ProfileView(View, PlayerEmbedMixin):
         character_id = self.character_ids[0]
         character = character or self.characters[character_id]
 
-        force_hb_temp = isinstance(character, HoyolabGICharacter)
+        # enka.cards renders only from enka.network showcase data, so HoYoLAB-sourced
+        # characters can't use it; fall back to the Hoyo Buddy template like GI does.
+        force_hb_temp = isinstance(character, HoyolabGICharacter) or (
+            card_settings.template == "enka1" and isinstance(character, HoyolabCharacter)
+        )
         if force_hb_temp and "hb" not in card_settings.template:
             card_settings.template = "hb1"
             await card_settings.save(update_fields=("template",))
@@ -564,6 +597,8 @@ class ProfileView(View, PlayerEmbedMixin):
         )
 
         if self.game is Game.STARRAIL:
+            if template == "enka1":
+                return await self._draw_enka_cards_card(i.client.session, character, card_settings)
             if "hb" in template:
                 return await self._draw_hb_hsr_character_card(character, card_settings, draw_input)
             return await self._draw_src_character_card(i.client.session, character, card_settings)
@@ -574,6 +609,8 @@ class ProfileView(View, PlayerEmbedMixin):
             return await self._draw_enka_card(i.client.session, character, card_settings)
 
         if self.game is Game.ZZZ:
+            if template == "enka1":
+                return await self._draw_enka_cards_card(i.client.session, character, card_settings)
             return await self._draw_hb_zzz_character_card(character, card_settings, draw_input)
 
         msg = f"draw_card not implemented for game {self.game} template {template}"

--- a/l10n/en_US.yaml
+++ b/l10n/en_US.yaml
@@ -336,6 +336,7 @@ profile.card_info.embed.title: About Character Build Cards
 profile.card_settings.button.label: Card settings
 profile.image_settings.button.label: Image settings
 profile.card_template_select.diff_author.description: "Designed by {author1} and programmed by {author2}"
+profile.card_template_select.enka.label: "Enka Network template {num}"
 profile.card_template_select.encard.label: "ENCard template {num}"
 profile.card_template_select.enka_classic.label: Classic Enka template
 profile.card_template_select.enkacard.label: "EnkaCard template {num}"


### PR DESCRIPTION
## Summary

Adds a new `enka1` card template for **HSR** and **ZZZ** that renders enka.network-style cards via the public [cards.enka.network](https://github.com/LumiFae/enka.cards) service. The service exposes plain image URLs, so no self-hosted renderer is required (unlike the existing `src`/`encard`/`enkacard` templates that POST to a local service).

### URL routing
- **Current showcase:** `GET /{hsr|zzz}/{uid}/{character_id}/image`
- **Saved enka builds:** `GET /u/{username}/{hash}/{character_id}/{build_id}/image` — game-agnostic route, reusing the `owner` + `build_id` info the `ProfileView` already holds (same trio `_draw_src_character_card` uses).

### Behavior
- The service renders from enka.network data only, so **custom art, custom color, and dark mode are disabled** for this template (`DISABLE_IMAGE`/`DISABLE_COLOR`/`DISABLE_DARK_MODE` all `True`).
- HoYoLAB-sourced characters (not on the enka showcase) **fall back to `hb1`**, mirroring the existing Genshin behavior.
- `substats` query param maps to the existing `show_substat_rolls` setting; `lang` maps to enka.network locale codes via the new `LOCALE_TO_ENKA_CARDS_LANG`.
- `run_zzz` now passes `owner=` to `ProfileView` (GI/HSR already did) so ZZZ saved builds resolve correctly.

Closes HB-116

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an Enka Network template option for Star Rail and ZZZ profiles with UI label and previews.
  * Character cards can render via Enka Network, including saved-build images and substat display.
  * Locale-aware rendering: card requests use language mapping so templates appear in the user’s language.

* **Bug Fixes**
  * Profile rendering now respects owner/build metadata when selecting card images.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->