### PR TITLE
fix(reminders): show reminder text in mobile notifications

### DIFF
--- a/hoyo_buddy/hoyo/auto_tasks/notes_check.py
+++ b/hoyo_buddy/hoyo/auto_tasks/notes_check.py
@@ -254,8 +254,13 @@ class NotesChecker:
             buttons = NotesView.get_open_game_buttons(account)
             view.add_items(buttons)
 
+            # Move the embed description into the message content so mobile
+            # notifications show the actual reminder text instead of "sent an image".
+            content = embed.description
+            embed.description = None
+
             message, errored = await cls._bot.dm_user(
-                account.user.id, embed=embed, file=file_, view=view
+                account.user.id, content=content, embed=embed, file=file_, view=view
             )
             view.message = message
 


### PR DESCRIPTION
## Summary

Discord mobile notifications show "XXX sent an image" when a DM contains an embed + image with no message content. Reminder DMs hit exactly this case, so the notification never revealed the actual reminder.

This moves the embed description (e.g. "Threshold X is reached") into the message `content` so the notification surfaces the real reminder text, and clears it from the embed to avoid duplicate text. The notes card, account info, title, thumbnail, and footer remain in the embed.

Closes #479 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved visibility of reminder text in direct messages by ensuring it displays in the message content instead of only within the embed, providing better readability across all platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->