### PR TITLE
feat(notif): rework DM notification timing and visibility

### DIFF
--- a/hoyo_buddy/cogs/admin.py
+++ b/hoyo_buddy/cogs/admin.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import datetime
 from typing import TYPE_CHECKING, Any, Literal, cast
 
 import discord
@@ -11,19 +12,24 @@ from discord.ext import commands
 from tortoise import Tortoise
 from tortoise.functions import Count
 
-from hoyo_buddy.db import HoyoAccount, Settings, User
+from hoyo_buddy.constants import AUTO_TASK_TOGGLE_FIELDS, NOTIF_SETTING_FIELDS
+from hoyo_buddy.db import DiscordEmbed, HoyoAccount, Settings, User
 from hoyo_buddy.db.models.gacha_history import GachaHistory
 from hoyo_buddy.draw.card_data import CARD_DATA
+from hoyo_buddy.embeds import DefaultEmbed, ErrorEmbed
 from hoyo_buddy.emojis import get_game_emoji
+from hoyo_buddy.enums import Locale
+from hoyo_buddy.hoyo.auto_tasks.embed_sender import EmbedSender
 from hoyo_buddy.hoyo.clients.ambr import AmbrAPIClient
 from hoyo_buddy.hoyo.clients.yatta import YattaAPIClient
 from hoyo_buddy.l10n import translator
-from hoyo_buddy.utils import add_to_hoyo_codes
+from hoyo_buddy.utils import add_to_hoyo_codes, get_now
 
 if TYPE_CHECKING:
     from discord.ext.commands.context import Context
 
     from ..bot import HoyoBuddy
+    from ..types import AutoTaskType
     from .search import Search
 
 
@@ -117,6 +123,75 @@ class Admin(commands.Cog):
             ]
         )
         await ctx.send(msg)
+
+    @commands.command(name="test-notifs", aliases=["tn"])
+    async def test_notifs_command(
+        self,
+        ctx: commands.Context,
+        count: int = 3,
+        embed_type: Literal["default", "error"] = "default",
+        task_type: str = "checkin",
+        stale_hours: int = 0,
+    ) -> Any:
+        """Enqueue fake notification embeds for the invoker and run EmbedSender.
+
+        Usage: hb tn [count] [default|error] [task_type] [stale_hours]
+        """
+        if task_type not in NOTIF_SETTING_FIELDS:
+            await ctx.send(f"Invalid task type, must be one of: {', '.join(NOTIF_SETTING_FIELDS)}")
+            return
+        task_type = cast("AutoTaskType", task_type)
+
+        account = await HoyoAccount.filter(user_id=ctx.author.id, current=True).first()
+        account = account or await HoyoAccount.filter(user_id=ctx.author.id).first()
+        if account is None:
+            await ctx.send("You have no accounts.")
+            return
+
+        settings = await Settings.get(user_id=ctx.author.id)
+        locale = settings.locale or Locale.american_english
+        toggle_field = AUTO_TASK_TOGGLE_FIELDS[task_type]
+        toggle_value = getattr(account, toggle_field)
+
+        before = await DiscordEmbed.filter(user_id=ctx.author.id).count()
+        for n in range(1, count + 1):
+            embed_cls = DefaultEmbed if embed_type == "default" else ErrorEmbed
+            embed = embed_cls(
+                locale,
+                title=f"Test notification {n}/{count}",
+                description=f"{task_type=} {stale_hours=}",
+            )
+            embed.add_acc_info(account, blur=False)
+            await DiscordEmbed.create(
+                embed, user_id=ctx.author.id, account_id=account.id, task_type=task_type
+            )
+
+        if embed_type == "error":
+            # DiscordEmbed.create disables the toggle for error embeds, restore it
+            await HoyoAccount.filter(id=account.id).update(**{toggle_field: toggle_value})
+
+        after = await DiscordEmbed.filter(user_id=ctx.author.id).count()
+        enqueued = after - before
+
+        if stale_hours and enqueued:
+            ids = (
+                await DiscordEmbed.filter(user_id=ctx.author.id)
+                .order_by("-id")
+                .limit(enqueued)
+                .values_list("id", flat=True)
+            )
+            await DiscordEmbed.filter(id__in=list(ids)).update(
+                created_at=get_now() - datetime.timedelta(hours=stale_hours)
+            )
+
+        message = await ctx.send(
+            f"Enqueued {enqueued}/{count} embeds (notif settings may filter), running EmbedSender..."
+        )
+        await EmbedSender.execute(self.bot)
+        remaining = await DiscordEmbed.filter(user_id=ctx.author.id).count()
+        await message.edit(
+            content=f"Enqueued {enqueued}/{count} embeds, {remaining} remaining in queue after send."
+        )
 
     @commands.command(name="get-cookies", aliases=["gc"])
     async def get_cookies_command(self, ctx: commands.Context, account_id: int) -> Any:

--- a/hoyo_buddy/db/models/__init__.py
+++ b/hoyo_buddy/db/models/__init__.py
@@ -1,3 +1,4 @@
+from .auto_task_result import AutoTaskResult
 from .card_settings import CardSettings
 from .challenge_history import ChallengeHistory
 from .custom_image import CustomImage

--- a/hoyo_buddy/db/models/auto_task_result.py
+++ b/hoyo_buddy/db/models/auto_task_result.py
@@ -1,0 +1,38 @@
+# pyright: reportAssignmentType=false
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from tortoise import fields
+
+from hoyo_buddy.utils import get_now
+
+from .base import BaseModel
+
+if TYPE_CHECKING:
+    from hoyo_buddy.types import AutoTaskType
+
+    from .hoyo_account import HoyoAccount
+
+
+class AutoTaskResult(BaseModel):
+    id = fields.IntField(pk=True, generated=True)
+    account: fields.ForeignKeyRelation[HoyoAccount] = fields.ForeignKeyField(
+        "models.HoyoAccount", related_name="auto_task_results"
+    )
+    task_type: AutoTaskType = fields.CharField(max_length=20)
+    success = fields.BooleanField()
+    completed_at = fields.DatetimeField()
+
+    account_id: int
+
+    class Meta:
+        unique_together = ("account", "task_type")
+
+    @classmethod
+    async def record(cls, *, account_id: int, task_type: AutoTaskType, success: bool) -> None:
+        await cls.update_or_create(
+            account_id=account_id,
+            task_type=task_type,
+            defaults={"success": success, "completed_at": get_now()},
+        )

--- a/hoyo_buddy/db/models/discord_embed.py
+++ b/hoyo_buddy/db/models/discord_embed.py
@@ -9,7 +9,9 @@ from tortoise.exceptions import IntegrityError
 
 from hoyo_buddy.constants import AUTO_TASK_TOGGLE_FIELDS, NOTIF_SETTING_FIELDS
 from hoyo_buddy.embeds import DefaultEmbed, ErrorEmbed
+from hoyo_buddy.utils import get_now
 
+from .auto_task_result import AutoTaskResult
 from .base import BaseModel
 from .hoyo_account import HoyoAccount
 from .notif_settings import AccountNotifSettings
@@ -31,6 +33,7 @@ class DiscordEmbed(BaseModel):
     )
     task_type: AutoTaskType = fields.CharField(max_length=20)
     type: Literal["default", "error"] = fields.CharField(max_length=7)
+    created_at = fields.DatetimeField(auto_now_add=True)
 
     user_id: int
     account_id: int
@@ -53,6 +56,17 @@ class DiscordEmbed(BaseModel):
         if toggle_field is None:
             logger.error(f"No toggle field found for task type: {task_type!r}")
             return
+
+        try:
+            await AutoTaskResult.record(
+                account_id=account_id, task_type=task_type, success=isinstance(embed, DefaultEmbed)
+            )
+        except IntegrityError:
+            # The account got deleted at the time this embed was created
+            return
+
+        if embed.timestamp is None:
+            embed.timestamp = get_now()
 
         if isinstance(embed, ErrorEmbed):
             await HoyoAccount.filter(id=account_id).update(**{toggle_field: False})

--- a/hoyo_buddy/db/models/notif_settings.py
+++ b/hoyo_buddy/db/models/notif_settings.py
@@ -46,3 +46,5 @@ class AccountNotifSettings(BaseModel):
     account: fields.OneToOneRelation[HoyoAccount] = fields.OneToOneField(
         "models.HoyoAccount", related_name="notif_settings", pk=True
     )
+
+    account_id: int

--- a/hoyo_buddy/hoyo/auto_tasks/embed_sender.py
+++ b/hoyo_buddy/hoyo/auto_tasks/embed_sender.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, ClassVar
 
 import discord
 from loguru import logger
+from seria.utils import shorten
 
 from hoyo_buddy.constants import AUTO_TASK_FEATURE_KEYS, NOTIF_SETTING_FIELDS
 from hoyo_buddy.db.models import AccountNotifSettings, DiscordEmbed, Settings
@@ -113,8 +114,9 @@ class EmbedSender:
                 locale = locale or await cls._get_locale(user_id)
                 content = cls._get_error_content(embed.task_type, locale, embed.account)
                 if content is not None:
-                    dc_embed.description = (
-                        f"{dc_embed.description}\n\n{content}" if dc_embed.description else content
+                    dc_embed.description = shorten(
+                        f"{dc_embed.description}\n\n{content}" if dc_embed.description else content,
+                        4096,
                     )
 
             to_send.append((embed, dc_embed))

--- a/hoyo_buddy/hoyo/auto_tasks/embed_sender.py
+++ b/hoyo_buddy/hoyo/auto_tasks/embed_sender.py
@@ -1,22 +1,27 @@
 from __future__ import annotations
 
 import asyncio
+import datetime
 from collections import defaultdict
 from typing import TYPE_CHECKING, ClassVar
 
 import discord
 from loguru import logger
 
-from hoyo_buddy.constants import AUTO_TASK_FEATURE_KEYS
-from hoyo_buddy.db.models import DiscordEmbed, Settings
+from hoyo_buddy.constants import AUTO_TASK_FEATURE_KEYS, NOTIF_SETTING_FIELDS
+from hoyo_buddy.db.models import AccountNotifSettings, DiscordEmbed, Settings
 from hoyo_buddy.enums import Locale
 from hoyo_buddy.l10n import LocaleStr
-from hoyo_buddy.utils import sleep
+from hoyo_buddy.utils import get_now, sleep
 
 if TYPE_CHECKING:
     from hoyo_buddy.bot.bot import HoyoBuddy
     from hoyo_buddy.db.models import HoyoAccount
     from hoyo_buddy.types import AutoTaskType
+
+MAX_EMBEDS_PER_MESSAGE = 10
+MAX_EMBED_CHARS_PER_MESSAGE = 5900
+STALE_EMBED_HOURS = 12
 
 
 class EmbedSender:
@@ -55,22 +60,72 @@ class EmbedSender:
         return Locale(settings.lang) if settings.lang else None
 
     @classmethod
-    async def _send_embeds(cls, user_id: int, embeds: list[DiscordEmbed]) -> None:
+    async def _is_notify_enabled(cls, embed: DiscordEmbed) -> bool:
+        notif_fields = NOTIF_SETTING_FIELDS.get(embed.task_type, ())
+        if len(notif_fields) < 2:
+            return True
+
+        notif_settings = await AccountNotifSettings.get_or_none(account_id=embed.account_id)
+        if notif_settings is None:
+            return True
+
+        field = notif_fields[0] if embed.type == "default" else notif_fields[1]
+        return bool(getattr(notif_settings, field))
+
+    @classmethod
+    def _chunk_embeds(
+        cls, items: list[tuple[DiscordEmbed, discord.Embed]]
+    ) -> list[list[tuple[DiscordEmbed, discord.Embed]]]:
+        chunks: list[list[tuple[DiscordEmbed, discord.Embed]]] = []
+        current: list[tuple[DiscordEmbed, discord.Embed]] = []
+        total_chars = 0
+
+        for row, embed in items:
+            if current and (
+                len(current) >= MAX_EMBEDS_PER_MESSAGE
+                or total_chars + len(embed) > MAX_EMBED_CHARS_PER_MESSAGE
+            ):
+                chunks.append(current)
+                current = []
+                total_chars = 0
+
+            current.append((row, embed))
+            total_chars += len(embed)
+
+        if current:
+            chunks.append(current)
+        return chunks
+
+    @classmethod
+    async def _send_embeds(cls, user_id: int, embeds: list[DiscordEmbed]) -> int:
+        """Send queued embeds to a user in batches, returns the number of deleted rows."""
+        deleted = 0
+        to_send: list[tuple[DiscordEmbed, discord.Embed]] = []
+        locale: Locale | None = None
+
         for embed in embeds:
-            await embed.fetch_related("account")
+            if not await cls._is_notify_enabled(embed):
+                deleted += await DiscordEmbed.filter(id=embed.id).delete()
+                continue
 
+            dc_embed = discord.Embed.from_dict(embed.data)
             if embed.type == "error":
-                locale = await cls._get_locale(user_id)
+                locale = locale or await cls._get_locale(user_id)
                 content = cls._get_error_content(embed.task_type, locale, embed.account)
-            else:
-                content = None
+                if content is not None:
+                    dc_embed.description = (
+                        f"{dc_embed.description}\n\n{content}" if dc_embed.description else content
+                    )
 
-            _, errored = await cls._bot.dm_user(
-                user_id, embed=discord.Embed.from_dict(embed.data), content=content
-            )
+            to_send.append((embed, dc_embed))
+
+        for chunk in cls._chunk_embeds(to_send):
+            _, errored = await cls._bot.dm_user(user_id, embeds=[e for _, e in chunk])
             await sleep("dm")
             if not errored:
-                await DiscordEmbed.filter(id=embed.id).delete()
+                deleted += await DiscordEmbed.filter(id__in=[row.id for row, _ in chunk]).delete()
+
+        return deleted
 
     @classmethod
     async def execute(cls, bot: HoyoBuddy) -> None:
@@ -81,6 +136,14 @@ class EmbedSender:
         async with cls._lock:
             try:
                 cls._bot = bot
+
+                stale = await DiscordEmbed.filter(
+                    type="default",
+                    created_at__lt=get_now() - datetime.timedelta(hours=STALE_EMBED_HOURS),
+                ).delete()
+                if stale:
+                    logger.info(f"{cls.__name__} deleted {stale} stale embeds")
+
                 cnt = await DiscordEmbed.all().count()
                 if cnt == 0:
                     return
@@ -88,7 +151,12 @@ class EmbedSender:
                 logger.info(f"Starting {cls.__name__} for {cnt} embeds")
 
                 while True:
-                    embeds = await DiscordEmbed.all().limit(100)
+                    embeds = (
+                        await DiscordEmbed.all()
+                        .order_by("-type", "id")
+                        .limit(100)
+                        .prefetch_related("account")
+                    )
                     if not embeds:
                         logger.debug("No embeds to send for")
                         break
@@ -98,7 +166,12 @@ class EmbedSender:
                     for embed in embeds:
                         embeds_dict[embed.user_id].append(embed)
 
+                    deleted = 0
                     for user_id, user_embeds in embeds_dict.items():
-                        await cls._send_embeds(user_id, user_embeds)
+                        deleted += await cls._send_embeds(user_id, user_embeds)
+
+                    if deleted == 0:
+                        # Every send in this batch errored, break to avoid spinning on them
+                        break
             except Exception as e:
                 bot.capture_exception(e)

--- a/hoyo_buddy/hoyo/auto_tasks/embed_sender.py
+++ b/hoyo_buddy/hoyo/auto_tasks/embed_sender.py
@@ -155,12 +155,14 @@ class EmbedSender:
 
                 logger.info(f"Starting {cls.__name__} for {cnt} embeds")
 
+                failed_users: set[int] = set()
+
                 while True:
+                    query = DiscordEmbed.all()
+                    if failed_users:
+                        query = query.exclude(user_id__in=failed_users)
                     embeds = (
-                        await DiscordEmbed.all()
-                        .order_by("-type", "id")
-                        .limit(100)
-                        .prefetch_related("account")
+                        await query.order_by("-type", "id").limit(100).prefetch_related("account")
                     )
                     if not embeds:
                         logger.debug("No embeds to send for")
@@ -178,12 +180,10 @@ class EmbedSender:
                     for embed in embeds:
                         embeds_dict[embed.user_id].append(embed)
 
-                    deleted = 0
                     for user_id, user_embeds in embeds_dict.items():
-                        deleted += await cls._send_embeds(user_id, user_embeds, notif_settings)
-
-                    if deleted == 0:
-                        # Every send in this batch errored, break to avoid spinning on them
-                        break
+                        deleted = await cls._send_embeds(user_id, user_embeds, notif_settings)
+                        if deleted == 0:
+                            # Every send for this user errored, skip them to avoid spinning
+                            failed_users.add(user_id)
             except Exception as e:
                 bot.capture_exception(e)

--- a/hoyo_buddy/hoyo/auto_tasks/embed_sender.py
+++ b/hoyo_buddy/hoyo/auto_tasks/embed_sender.py
@@ -61,13 +61,11 @@ class EmbedSender:
         return Locale(settings.lang) if settings.lang else None
 
     @classmethod
-    async def _is_notify_enabled(cls, embed: DiscordEmbed) -> bool:
+    def _is_notify_enabled(
+        cls, embed: DiscordEmbed, notif_settings: AccountNotifSettings | None
+    ) -> bool:
         notif_fields = NOTIF_SETTING_FIELDS.get(embed.task_type, ())
-        if len(notif_fields) < 2:
-            return True
-
-        notif_settings = await AccountNotifSettings.get_or_none(account_id=embed.account_id)
-        if notif_settings is None:
+        if len(notif_fields) < 2 or notif_settings is None:
             return True
 
         field = notif_fields[0] if embed.type == "default" else notif_fields[1]
@@ -98,14 +96,19 @@ class EmbedSender:
         return chunks
 
     @classmethod
-    async def _send_embeds(cls, user_id: int, embeds: list[DiscordEmbed]) -> int:
+    async def _send_embeds(
+        cls,
+        user_id: int,
+        embeds: list[DiscordEmbed],
+        notif_settings: dict[int, AccountNotifSettings],
+    ) -> int:
         """Send queued embeds to a user in batches, returns the number of deleted rows."""
         deleted = 0
         to_send: list[tuple[DiscordEmbed, discord.Embed]] = []
         locale: Locale | None = None
 
         for embed in embeds:
-            if not await cls._is_notify_enabled(embed):
+            if not cls._is_notify_enabled(embed, notif_settings.get(embed.account_id)):
                 deleted += await DiscordEmbed.filter(id=embed.id).delete()
                 continue
 
@@ -163,6 +166,13 @@ class EmbedSender:
                         logger.debug("No embeds to send for")
                         break
 
+                    notif_settings = {
+                        settings.account_id: settings
+                        for settings in await AccountNotifSettings.filter(
+                            account_id__in={embed.account_id for embed in embeds}
+                        )
+                    }
+
                     # Organize embeds into a dictionary with user_id as key
                     embeds_dict: defaultdict[int, list[DiscordEmbed]] = defaultdict(list)
                     for embed in embeds:
@@ -170,7 +180,7 @@ class EmbedSender:
 
                     deleted = 0
                     for user_id, user_embeds in embeds_dict.items():
-                        deleted += await cls._send_embeds(user_id, user_embeds)
+                        deleted += await cls._send_embeds(user_id, user_embeds, notif_settings)
 
                     if deleted == 0:
                         # Every send in this batch errored, break to avoid spinning on them

--- a/hoyo_buddy/ui/account/view.py
+++ b/hoyo_buddy/ui/account/view.py
@@ -2,9 +2,12 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from hoyo_buddy.db import HoyoAccount, get_dyk
+from discord.utils import format_dt
+
+from hoyo_buddy.constants import AUTO_TASK_FEATURE_KEYS
+from hoyo_buddy.db import AutoTaskResult, HoyoAccount, get_dyk
 from hoyo_buddy.embeds import DefaultEmbed
-from hoyo_buddy.emojis import get_game_emoji
+from hoyo_buddy.emojis import CHECK, get_game_emoji
 from hoyo_buddy.l10n import EnumStr, LocaleStr
 from hoyo_buddy.ui import View
 
@@ -21,7 +24,7 @@ if TYPE_CHECKING:
 
     from hoyo_buddy.db import User
     from hoyo_buddy.enums import Locale
-    from hoyo_buddy.types import Interaction
+    from hoyo_buddy.types import AutoTaskType, Interaction
 
 
 class AccountManager(View):
@@ -38,6 +41,7 @@ class AccountManager(View):
         self.locale = locale
         self.accounts = accounts
         self.selected_account: HoyoAccount | None = None
+        self.task_results: list[AutoTaskResult] = []
 
     @property
     def _acc_embed(self) -> DefaultEmbed:
@@ -56,8 +60,40 @@ class AccountManager(View):
         )
         if account.nickname:
             embed.add_field(name=LocaleStr(key="account_username"), value=account.username)
+        if self.task_results:
+            lines = [
+                f"{self._get_task_label(result.task_type)}: "
+                f"{CHECK if result.success else '❌'} {format_dt(result.completed_at, 'R')}"
+                for result in self.task_results
+            ]
+            embed.add_field(
+                name=LocaleStr(key="auto_task_status_field_name"),
+                value="\n".join(lines),
+                inline=False,
+            )
         embed.set_footer(text=LocaleStr(key="account_manager_footer"))
         return embed
+
+    def _get_task_label(self, task_type: AutoTaskType) -> str:
+        feature_key = AUTO_TASK_FEATURE_KEYS.get(task_type)
+        if feature_key is None:
+            return task_type
+
+        if "mimo" in task_type:
+            return LocaleStr(
+                custom_str="{mimo_title} {label}",
+                mimo_title=LocaleStr(key="point_detail_tag_mimo", mi18n_game="mimo"),
+                label=LocaleStr(key=feature_key),
+            ).translate(self.locale)
+        return LocaleStr(key=feature_key).translate(self.locale)
+
+    async def _fetch_task_results(self) -> None:
+        if self.selected_account is None:
+            self.task_results = []
+        else:
+            self.task_results = await AutoTaskResult.filter(
+                account_id=self.selected_account.id
+            ).order_by("task_type")
 
     def _add_items(self) -> None:
         if self.accounts:
@@ -84,6 +120,7 @@ class AccountManager(View):
 
     async def start(self, i: Interaction) -> None:
         self._add_items()
+        await self._fetch_task_results()
         embed = self._acc_embed
         await i.response.defer(ephemeral=True)
         self.message = await i.edit_original_response(
@@ -104,4 +141,5 @@ class AccountManager(View):
             )
             await view.start(i)
         else:
+            await self._fetch_task_results()
             await self.absolute_edit(i, embed=self._acc_embed, view=self)

--- a/l10n/en_US.yaml
+++ b/l10n/en_US.yaml
@@ -781,6 +781,7 @@ web_events_notify_toggle_label: Notify on new web events
 web_events_cmd_desc: View ongoing web events and set notifier
 web_events_embed_footer: Use /web-events to configure notifications
 auto_task_error_dm_content: "**{feature}** has been **__disabled__** for `{account}` due to an error, you can enable it back using {command}.\nIf this error persists or you don't know how to fix it, please find help in our [Discord server](<https://link.seria.moe/hb-dc>)."
+auto_task_status_field_name: Auto Task Status
 is_support_custom_image_desc: Supports custom image
 is_not_support_custom_image_desc: Doesn't support custom image
 missing_permissions_error_title: Hoyo Buddy is Missing Permissions

--- a/migrations/models/4_20260727213358_notification_rework.py
+++ b/migrations/models/4_20260727213358_notification_rework.py
@@ -1,0 +1,131 @@
+from tortoise import BaseDBAsyncClient
+
+RUN_IN_TRANSACTION = True
+
+
+async def upgrade(db: BaseDBAsyncClient) -> str:
+    return """
+        CREATE TABLE IF NOT EXISTS "autotaskresult" (
+    "id" SERIAL NOT NULL PRIMARY KEY,
+    "task_type" VARCHAR(20) NOT NULL,
+    "success" BOOL NOT NULL,
+    "completed_at" TIMESTAMPTZ NOT NULL,
+    "account_id" INT NOT NULL REFERENCES "hoyoaccount" ("id") ON DELETE CASCADE,
+    CONSTRAINT "uid_autotaskres_account_462643" UNIQUE ("account_id", "task_type")
+);
+        ALTER TABLE "cardsettings" ALTER COLUMN "custom_images" TYPE JSONB USING "custom_images"::JSONB;
+        ALTER TABLE "cardsettings" ALTER COLUMN "highlight_substats" TYPE JSONB USING "highlight_substats"::JSONB;
+        ALTER TABLE "challengehistory" ALTER COLUMN "json_data" TYPE JSONB USING "json_data"::JSONB;
+        ALTER TABLE "discordembed" ADD "created_at" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP;
+        ALTER TABLE "discordembed" ALTER COLUMN "data" TYPE JSONB USING "data"::JSONB;
+        ALTER TABLE "farmnotify" ALTER COLUMN "item_ids" TYPE JSONB USING "item_ids"::JSONB;
+        ALTER TABLE "hoyoaccount" ALTER COLUMN "redeemed_codes" TYPE JSONB USING "redeemed_codes"::JSONB;
+        ALTER TABLE "jsonfile" ALTER COLUMN "data" TYPE JSONB USING "data"::JSONB;
+        ALTER TABLE "leaderboard" ALTER COLUMN "extra_info" TYPE JSONB USING "extra_info"::JSONB;
+        ALTER TABLE "user" ALTER COLUMN "temp_data" TYPE JSONB USING "temp_data"::JSONB;
+        ALTER TABLE "user" ALTER COLUMN "dismissibles" TYPE JSONB USING "dismissibles"::JSONB;"""
+
+
+async def downgrade(db: BaseDBAsyncClient) -> str:
+    return """
+        ALTER TABLE "user" ALTER COLUMN "temp_data" TYPE JSONB USING "temp_data"::JSONB;
+        ALTER TABLE "user" ALTER COLUMN "dismissibles" TYPE JSONB USING "dismissibles"::JSONB;
+        ALTER TABLE "jsonfile" ALTER COLUMN "data" TYPE JSONB USING "data"::JSONB;
+        ALTER TABLE "farmnotify" ALTER COLUMN "item_ids" TYPE JSONB USING "item_ids"::JSONB;
+        ALTER TABLE "hoyoaccount" ALTER COLUMN "redeemed_codes" TYPE JSONB USING "redeemed_codes"::JSONB;
+        ALTER TABLE "leaderboard" ALTER COLUMN "extra_info" TYPE JSONB USING "extra_info"::JSONB;
+        ALTER TABLE "cardsettings" ALTER COLUMN "custom_images" TYPE JSONB USING "custom_images"::JSONB;
+        ALTER TABLE "cardsettings" ALTER COLUMN "highlight_substats" TYPE JSONB USING "highlight_substats"::JSONB;
+        ALTER TABLE "discordembed" DROP COLUMN "created_at";
+        ALTER TABLE "discordembed" ALTER COLUMN "data" TYPE JSONB USING "data"::JSONB;
+        ALTER TABLE "challengehistory" ALTER COLUMN "json_data" TYPE JSONB USING "json_data"::JSONB;
+        DROP TABLE IF EXISTS "autotaskresult";"""
+
+
+MODELS_STATE = (
+    "eJztXetv2zgS/1cEf9kukCsa57nB4QDZVhLfJnZgOe22zYKgJTrWRqK8ejR19/q/H6mHrQ"
+    "elSPJLFvihRSxyKOk31HBmODP8p2WYKtLt96KimC52BqajTWXkOBp+tltXwj8tDA1E/sjt"
+    "dyS04Hy+6kUvOHCie4TQp8CUwo5STGzHgopD+kyhbiNySUW2YmlzRzMxuYpdXacXTYV0JF"
+    "SrSy7W/nYRcMxn5MyQRRq+/kkua1hF35Ed/py/gKmGdDX2GsHTAE2lz+C1A2cx99r62Ln2"
+    "COhdJ0AxddfAaaL5wpmZeEmlYYdefUYYWdBBauR96OMGMISX/EcnFxzLRctnVlcXVDSFru"
+    "5E3n8CVtdaAAyGYyBLYwBaJRBTTEzRJs/qc/WZPsK/2senF6eXJ+enl6SL95jLKxc//Vuv"
+    "EPIJPZwG49ZPrx060O/hgb5C2WP2AhCUlBlSXjQMplDTXQulQe+Ypo4gZgOfO06CDxMyUB"
+    "VGhBdWnFhNxxD2kDdbYEUOzp3h8I6ObNj237p3oT+mv03y2fjf1uDxviON3h3/Si+TTpqD"
+    "ogzKY4jtKgqy7bUZEhmHM6Q4QwzNMIED7ZeKjGDScwZUYUA10cSk5wwoyYCJu1jnA0iQc/"
+    "grwL/G9E+Qc/hLwq9a8HWd6Z+k5wyowoA1PoAkPWdAcQZYSEXIqDj908Qc+tLQV5v4aWIO"
+    "fRVDjDoVjDnEVRWgN0biTFmPKes6LJgjcaYUZ8ormgD0DdF7luNBnHCHkC+vHBTm1FU6fY"
+    "m48eiFCVReXqGlglSL2TaZLr/AR5rm1RCjsUn+85jVJy8FscL6GAIH8625MMXVWAflVv0Z"
+    "TsXw6ur+nqIYeKMT/mSCAXlz5POkK8pdsSe1fsa4EAedNhltI3kFYvjsvTJ9OPooocvedc"
+    "wxtF9GyPbfNu3Uj/c4ynXnk77U7WGt+m7Ukf81OpM8/4o3Qf4s6uAv5dgv6tAPmFjbibdt"
+    "f/6KDylsuzNoscGNESUwJg+/LSm8TZgN+B3oCD87M4rthxxMP4qj7q04etf+8GtCFgctba"
+    "8pvuRVUwT3o/RtX4xuWb+g6hmVuiqAjFWrR+ByNAOxIU/SJnBXA+L34R/NYsK4fy/JY/H+"
+    "IcaJnjiWaEvbu7pIXH13nvgOloMIn/rjW4H+FL4MB5IHp2k7z5Z3x1W/8ZcWfSa6/gBsvg"
+    "KoRjEJL4eXYqyuzabvvuXXBpaJlLpYQAW8Ni2kPePf0WI3SmA9Pp3Nq4FvKOObUxm7ZIS8"
+    "KJBYe666qJCe24v6+NpSiPpBhkNWgKJrI1+zoA/MlcZ9Ko1J1hTVG5N0DVQdLwtojpeZiu"
+    "NlUm9UofUC6MdXUnOM0XHdsYTu6NqOaQDNIOKToa7/Vx4OMuZ2kjCpOWqKI/xP0DV7awtf"
+    "6+ufrd2DTyGJgR9O53f34h/Jmd69G3aSeiAdoMNmw9wieFoLCrNplZI0GfSVJE4guuvyIc"
+    "QFTp4kDxlxkSlwLpICR3EtC1HNhc7jNOJj9D1j7UwRNgHqPFNJ+mOcP+2XltLdcHATdk9+"
+    "C2z0HQSN6iyIU3M+lOeDg4y5TtAp5RSL0OxOsWnNJsfbEvpxQXPSLiBpTtqZooY2JZxiM2"
+    "LsWxC/lHWLRen4xltx5cYDznaJoQYdYJm6XtohyRyAs6A4C2ba80wn/xxgz5GiQR1QLMvy"
+    "IWcUzoxKzPDndCmNn03N1f411H7XRsA4AdBiuBpzP4g4IY8MKPEReP40pp4jYddIuXVjsI"
+    "e0NdYxWzfSQL7tD66EG4TtmYaFvjGHivOE5bE4Gon9uyvh1sQvULsSZAdawghq+hO+HQ5+"
+    "F/thU0AjnFjqE/7y5cuV8AVhHdm28MXEiPywzCc8Ho6vhDGCli2YU2E8Q4bmSYT9K1rUdc"
+    "p01XW050xnaISoSVskv7XbJycX7Q8n55dnpxcXZ5cflt7RdFOecd3p39CPKcaENzdSQif2"
+    "mrsoj6Ev/LBYUHT7JDL1arV3MoM6/UrRLVnNTWvRYu2fJPsc5e6hhL1nkd4b3kdxfSBtBG"
+    "0Cpv9jeV8egrP/3RS3tGTerlTeA7Y7EMoxOzj6LRSczTGaJi2Ia87rSKx1piKZEVFdf+Wx"
+    "oqvs/LSABnd+mqnB0aaEYzgusCuq6+lR6rwD25If+iPxDoidz7JMlPO5ZkFdgJOFbT/h+2"
+    "H3SrhHBlk0qbZN3swkVx8eRxK47nfH/SFR+B9cCwlTYoCT8Z6w+NAF8q3YG366EsS5qUB9"
+    "Qe6kCPYMqubrE+7f34DxrSSOpdGVoBnPgCyhkO5V69AiiE10U3kBjuboiJgOt/3Pj6AnXR"
+    "PbQiKPNtMWrkDei1gYpFWUZfHxjhgDP378IG8LVX0BoG3TlyaGhTjqAcLmuztpcENoZ1Qt"
+    "WTKGEA+G9+Ld5ysBYtOAlNKaaGSmeaDUwpqgCxlrwcLQWmTtRvsUSbt84fhbpYf1rectP4"
+    "GfY2mWExg7/YE4+szejegw/CKdz2NJTC5YxDB1QBhvWCaeMU7JoxlrHc2IsFqJyVE6zuJa"
+    "s1iH5EVLKElh/+YpSWcF1qWzzGXpLLkq/UW1c/bSlO3CjxGt5bmvGdS7cNyvlV62Qa+MF+"
+    "rT98IdWA6ZSPNRri/G67gMm9hVOKtr6dz/st+SZtxuDUTy8YciiU+kV6ZY9toSmw+WnkY3"
+    "O4gp6N4EcHcePcbDsncUls031PiGWh1YcOAbar17IpQwRjpLcVs15qptqqFEuu2l8mxZQd"
+    "C0YrM72b3J2T/jwnivwnhPskOzFdNSJWOC4l8jqz1fgvg90bJnbYQIN+3WNO3K+oM24gqq"
+    "m2jYdRAnLymyk5IipRFuLribzoGz6MZvpeohMcoGbsW0yAuqQ6wvgoXiQLZmgjWNlxLZQ1"
+    "gQV8+5r6QOLNiYr4QhNDaAKi+Ms19f1DW0DO/sI2ZYd6T1KM+WnJJ+eNWPH4R01FTTEmH6"
+    "2qxlLS9PLULFEzWL56iRBoNMzVLpmVEanpS5y9gOXjp4J0vjWsvdDVRmMCePKdaeu+Q905"
+    "5bzF961exZAEqYbhqZVhO692PxNKb9L4gRPhW38yJE3M6rnM9kQUtzFiXm9IqgSahvzGVR"
+    "JQabx1/v28lXKP460ArLyP8VBf9YGB9LdAUujmqCiiObjWyp2RqjqYRqzYIoN56l6hol4A"
+    "x67256Hh8OjMDWiNEGdGgzDLw8RBOEHNzalOTZkUTlNXlq5KVNs/jQrNKcLa8a7880wge1"
+    "s+0Zzx8le0X2srxVcliC7w1f1bJU35aOtwrQS2i4/NiCvXuoaixyD1ql1rWp59oAc5dZUj"
+    "YT2zQhx5eBL/z2DM5oIYcsgK91E2ZN3zRtAuMpJT5AlHMg7A0fO3eS8DCSun25H2yJLd1Q"
+    "XmN8x3EkiXcM0E/XAP2Ug14N9JM1QD/ZH+gf3n84TMxfNQwsZq37HLCjRHxqF4GZ2/TNt+"
+    "m5K3yrZv1+LM+o4c8wPRN+gWzbc0Y6RtwRWyrzGooKL9aXm5u8rmvzM4PjAe5lq7lEaeq8"
+    "vhaHfsuLHFdkmq/IKKb5orHOP8w5fGxFUmfubiToZRvFe4gY+sZKz8mWXCuKRgC+9bK16J"
+    "umoJKlkWJETahJlUD5vAjKyXitCMrnGShP5xVQ9omah/LxSQGUj0+yi6qdJFG20HNQDrrK"
+    "KryirrPgaA0/SiNZEuUrgZb27pIlWaLFtpVKZbCLiJNsaZISJlhTXkrXDYzQNG+Sb15gz9"
+    "2JrikMEyovwWpFxPOriudXGZphAkPDmuEaYG5qrIiJTLOVTbw7N9a2/O6b3sZTiZ2wAMoM"
+    "KS8aQ3a/cZ57gpbP7uKz2wsIt5CKECP0Mxf2BCUHvaRI8fCjpX1K4p4m5tBXgX7iMrKCCi"
+    "If0PKzNCshr1rwtTL0ITHHvoyUVxTTmENcdYll0nMOVOKARXAuH2aXouX5K3kgO+ZcU6qi"
+    "HCXmMDNiGqHthIKg0pk8zAE2kBxaM9yblBvqscxbhf1qlFW5nh6C8/0w+E503jXZHh2Bc/"
+    "0wuE7V7TXZHhuC8732fPd9OtWZnqDnHK89xyOqb1Wmp4fgfK8z3xXXshBrKyPXDxCh4tZ/"
+    "CevfF4lIJVCqrNCh7Ep9aUper2+N+vu+H1HXgaJDjcJaReBlDsJFXp1FHi+2zYtt14EFRQ"
+    "sOrHEwWWJ/1/O3kC+JvAZj8ekEQ1z/PkI6dNjhTwHkIhluTEYbeYM1CPyYpPCOO1oTqeQZ"
+    "S03EiVaoZKkzZXBKFlNtIk5e1fM1cRqYDrJXZdabAlOp7LQEosBGjkPumoNsWEu5gGTz08"
+    "88hOXIuAepr+VPR1qIH7w1J4sjF6//3xC8SiZC+gac94apLMhl21FeCuRftomnYS9+yt6O"
+    "9eFmHKBeQOrvFNvtH6DODzE8hEMPNpdwfoegiqyJSQZiidpoc6601RMdN5xwHtYrWGacE3"
+    "HJE873KYfZdSeK5QRlVJ+oV0aQ2L3tSx+le2kwvhKITaWhb8hA2AH6BDiaoyOaJiTJpFEh"
+    "Nlv0MpEE4HrUlwY9+bb/cCVQqT21NIRVe6bNIx3FzmdZBr37G3KDycK2gWo8R5rHt5I4lk"
+    "Z+B/ItEEysWJdWhVWD52jzHO3yPP4Gdbdc0aYlBa/YVKRiU93qdzTUhx4/yAQzUkVyjjHB"
+    "rOSQg0Z8o+eu8mIoWxbC6Du5GdDw1CxjocWp1rLTqviaWv/8POS97pqYaVFnNcNMS/iys8"
+    "00TDtu68zQlZkWlh7jJlr9TDQCa2ULrVaLHVGjZKqVHz9hqlDdg+7jaCQNup8JgESX7oCH"
+    "4SdpRATxE77pA+mPB6l3JZwSxVwehb/OnvADUbnPvR49oskT2gu/R/Drkg5ObgN6fbk7fK"
+    "S24G9PWOreDsHwGnwSR9QP5/WRRh+lHljd9pg8V0ccEwOODHPc9rT+cNRj8kxydySOu7eg"
+    "K47IkxyTB/vY70lDII+HI4lcoM92Jw7EEbjuy/Kjd+3csznu+wOR/Ljwh+zQp6Jj0kft9x"
+    "7J/cnUkMmF3wraDv40PGlfnC9nIP2RN/nke/HuLq0G8HNqdxgD54WJ+vt2laNM4+Q83KrO"
+    "4VarJK81c8Q4vw+C39SpWIXRUTrO4Tpz2FfEiW3mIOsb1NOMlg2o69mnm6XJ66yvldWLN6"
+    "GQ+PKuKsBpao5vIvwbfg90iIyjr/IBZpDvDuGz+sMbpIesA3HGEI2pmLUJmJ0ZEeozU2cY"
+    "LvngxggbVNlgE6AGqxNbgym0sGUoMRxYD51XhF5UyCi5VAjbCDWHNwbvzHQtG0zQ1LRKT9"
+    "wkLYc2VU6Gn4m3GcdvTjZQjc8hrUUs8tHBHES6jJtn7PlEY+qzN3yiEf37iYKuR5ZgHTZ6"
+    "dhLfkL0dpEPyiCkuZO/Ph/2bVz76uFjgdE7cdDps2noB9PMrufURo+ObH8U3P541oFDx6i"
+    "CjVPX/JN3uAk9as8lxayfTe/ORJzPbqgZ3ipDjXQTvHz9+VMM7RbhTvNuHireDoOHjVlWQ"
+    "Z4zAi7qUkOl+HABQF2UreMcJ+TJaahmtOuOTpHyql8CdrotVgU/RcuRLIE9XyKrIp2g58m"
+    "8gv1b47Fv1bcKM+oLOrKrVbfbqOthObZu1nFIejgyHVIhvtjMqZGN90vHzfFDc/bRR9xO1"
+    "SEDZ9PIY0R4K9f176mKF4i1MXE13NGy/p7f9z7YMnV2kNKRiCr0AF6iERUlKBxUm6HnMWZ"
+    "1jzlTNNjTb1gjQpepmJun2UTXzF+MEQMv55Uj4hSrBVDi0fznoUpol9KNIVBBte7tUU5Ei"
+    "WF3Sr0RxpkPZ4UsEUdmOaQDNIOrMunB5Q/XpSE1Fi5fqK4ZTsGm8JlLN3GCvWoRuk+XnGl"
+    "hyrqSdJiJLU2YthqUWtBzl2Wpw1ac21hrPCF0zI/QbsuzMs7zZ0EZIGpik3z47K7CXRHpl"
+    "n9ZN2xJhbvNSe3ZB9waiu5UKdeSODvOghWzbJULC69QdUgGEn/8HCTm4fQ=="
+)


### PR DESCRIPTION
The DM queue decouples notifications from auto task runs, so delayed deliveries confused users: notifications arrived after the setting was turned off, and a missing DM read as the task never running. This reworks the pipeline so delayed delivery no longer misleads.

- Re-check notification settings at send time and drop embeds whose setting was disabled while queued
- Stamp the action time on every embed at enqueue via the native embed timestamp
- Record each run's outcome in a new `AutoTaskResult` model and show per-task status with relative time in `/accounts`, so the DM is no longer the only signal a task ran
- Expire success embeds older than 12h, drain errors before successes, and batch up to 10 embeds per DM with the error notice folded into the embed description
- Add owner command `hb test-notifs` to exercise the pipeline

The migration also carries JSON to JSONB conversions aerich emitted from the current tortoise version; they rewrite the affected tables, worth reviewing before running on prod.